### PR TITLE
Inventory workflow workflow manager - provision in 2.3.5.3

### DIFF
--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -1791,45 +1791,31 @@ class Inventory(DnacBase):
         self.log("Device '{0}' did not transition to the Managed state within the retry limit.".format(device_ip), "WARNING")
         return False
 
-    def provision_wired_device_v1(self, device_ip, site_name, device_type):
+    def provision_wired_device_v1(self, device_ip, site_name_hierarchy, device_type):
         """
         Provisions a device for versions <= 2.3.5.6.
         Parameters:
             device_ip (str): The IP address of the device to provision.
-            site_name (str): The name of the site where the device will be provisioned.
+            site_name_hierarchy (str): The name of the site where the device will be provisioned.
             device_type (str): The type of device being provisioned.
-        Returns:
-            self (object): An instance of the class after the provision operation is performed.
         Description:
             This method provisions a device with the specified IP address,
             site name, and device type for software versions 2.3.5.6 or earlier.
             It handles the necessary configurations and returns a success status.
         """
 
-        provision_params = {'deviceManagementIpAddress': device_ip, 'siteNameHierarchy': site_name}
+        provision_params = {'deviceManagementIpAddress': device_ip, 'siteNameHierarchy': site_name_hierarchy}
         try:
             response = self.dnac._exec(family="sda", function='provision_wired_device', op_modifies=True, params=provision_params)
             self.log("Received API response from 'provision_wired_device': {0}".format(response), "DEBUG")
 
             if response:
-                exec_id = response.get("executionId")
-                response = self.get_execution_details(exec_id)
-                while True:
-                    if response.get("status") == "SUCCESS":
-                        self.log("Device: {0} successfully provisioned to the site {1}".format(device_ip, site_name), "INFO")
-                        self.provision_count += 1
-                        self.provisioned_device.append(device_ip)
-                        break
-                    elif response.get("status") == "FAILURE":
-                        self.log("Failed to provision device: {0}".format(device_ip), "ERROR")
-                        raise Exception
-                    else:
-                        self.log("Provisioning in progress for device: {0}".format(device_ip), "DEBUG")
+                self.check_execution_response_status(response, "provision_wired_device").check_return_status()
+                self.provision_count += 1
+                self.provisioned_device.append(device_ip)
 
         except Exception as e:
             self.handle_provisioning_exception(device_ip, e, device_type)
-
-        return self
 
     def provision_wired_device_v2(self, device_ip, site_name):
         """

--- a/plugins/modules/inventory_workflow_manager.py
+++ b/plugins/modules/inventory_workflow_manager.py
@@ -1700,7 +1700,7 @@ class Inventory(DnacBase):
 
         for device_info in provision_wired_list:
             device_ip = device_info['device_ip']
-            site_name = device_info['site_name']
+            site_name_hierarchy = device_info['site_name']
             device_ip_list.append(device_ip)
             device_type = "Wired"
             resync_retry_count = device_info.get("resync_retry_count", 200)
@@ -1726,9 +1726,9 @@ class Inventory(DnacBase):
                 continue
 
             if self.get_ccc_version_as_integer() <= self.get_ccc_version_as_int_from_str("2.3.5.3"):
-                self.provision_wired_device_v1(device_ip, site_name, device_type)
+                self.provision_wired_device_v1(device_ip, site_name_hierarchy, device_type)
             else:
-                self.provision_wired_device_v2(device_ip, site_name)
+                self.provision_wired_device_v2(device_ip, site_name_hierarchy)
 
         # Handle final provisioning results
         self.handle_final_provisioning_result(total_devices, self.provision_count, self.already_provisioned_count, device_ip_list, device_type)
@@ -1817,7 +1817,7 @@ class Inventory(DnacBase):
         except Exception as e:
             self.handle_provisioning_exception(device_ip, e, device_type)
 
-    def provision_wired_device_v2(self, device_ip, site_name):
+    def provision_wired_device_v2(self, device_ip, site_name_hierarchy):
         """
         Provisions a device for versions > 2.3.5.6.
         Parameters:
@@ -1829,7 +1829,7 @@ class Inventory(DnacBase):
             It performs the necessary configurations and returns a success status.
         """
         try:
-            site_exist, site_id = self.get_site_id(site_name)
+            site_exist, site_id = self.get_site_id(site_name_hierarchy)
             device_ids = self.get_device_ids([device_ip])
             device_id = device_ids[0]
 
@@ -1839,7 +1839,7 @@ class Inventory(DnacBase):
             is_device_assigned_to_site = self.is_device_assigned_to_site(device_id)
 
             if not is_device_assigned_to_site:
-                self.assign_device_to_site(device_ids, site_name, site_id)
+                self.assign_device_to_site(device_ids, site_name_hierarchy, site_id)
 
             if not is_device_provisioned:
                 self.provision_device(provision_params, device_ip)


### PR DESCRIPTION
## Description

 Device Provisioning - version 2.3.5.3

Problem:
Error in Playbook: Reported failure to provision wired devices, even though the UI indicated success.
Log Details: DNAC logs showed an error due to a 'NoneType' object not having the expected get attribute.
Cause: The check_task_response_status function was incompatible with older API versions used for device provisioning, causing it to misinterpret API responses.

Solution:
Updated Logic for Provisioning:
New handling logic for older API versions was added in inventory_workflow_manager.py.
The function now retrieves an executionId after initiating provisioning, which is used to continuously check the provisioning status.
Status is checked in real-time, logging progress as:
Success: Logs the success message and records the device in the provisioned list.
Failure: Logs an error and raises an exception.
In Progress: Logs a status update without interrupting the process.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

