### PR TITLE
bug fix in provision workflow manager

### DIFF
--- a/plugins/modules/provision_workflow_manager.py
+++ b/plugins/modules/provision_workflow_manager.py
@@ -820,45 +820,6 @@ class Provision(DnacBase):
                     self.log("Managed AP Location must be a floor", "CRITICAL")
                     self.module.fail_json(msg="Managed AP Location must be a floor", response=[])
 
-        else:
-            self.log("Checking for mandatory interface fields in Catalyst Center version >= 2.3.7.6", "DEBUG")
-            interfaces = self.validated_config.get("dynamic_interfaces", [])
-            self.log("Configured interfaces: {0}".format(interfaces), "DEBUG")
-            has_interface_name = False
-            has_vlan_id = False
-
-            if interfaces is None:
-                self.msg = ("It appears that the 'dynamic_interfaces' parameter is either missing or set to None. "
-                            "Please note that this parameter is required for provisioning a wireless device in "
-                            "Catalyst Center version 2.3.7.6 or higher.")
-                self.log(self.msg, "ERROR")
-                self.result['response'] = self.msg
-                self.status = "failed"
-                self.check_return_status()
-
-            for interface in interfaces:
-                if 'interface_name' in interface:
-                    has_interface_name = True
-                if 'vlan_id' in interface:
-                    has_vlan_id = True
-                self.log("Presence of 'interface_name' in interfaces: {0}".format(has_interface_name), "DEBUG")
-                self.log("Presence of 'vlan_id' in interfaces: {0}".format(has_vlan_id), "DEBUG")
-
-            missing_fields = []
-            if not has_interface_name:
-                missing_fields.append("interface_name")
-            if not has_vlan_id:
-                missing_fields.append("vlan_id")
-
-            if missing_fields:
-                missing_fields_str = ', '.join(missing_fields)
-                self.msg = ("The following required fields for provisioning a wireless device in version"
-                            " 2.3.7.6 are currently missing: {0}".format(missing_fields_str))
-                self.log(self.msg, "ERROR")
-                self.result['response'] = self.msg
-                self.status = "failed"
-                self.check_return_status()
-
         wireless_params[0]["dynamicInterfaces"] = []
         if self.validated_config.get("dynamic_interfaces"):
             for interface in self.validated_config.get("dynamic_interfaces"):
@@ -873,7 +834,8 @@ class Provision(DnacBase):
                 wireless_params[0]["dynamicInterfaces"].append(interface_dict)
 
         wireless_params[0]["skip_ap_provision"] = self.validated_config.get("skip_ap_provision")
-        wireless_params[0]["primaryManagedAPLocationsSiteIds"] = self.validated_config.get("primary_managed_ap_Locations")
+        primary_ap_location = self.validated_config.get("primary_managed_ap_Locations") or self.validated_config.get("managed_ap_locations")
+        wireless_params[0]["primaryManagedAPLocationsSiteIds"] = primary_ap_location
         wireless_params[0]["secondaryManagedAPLocationsSiteIds"] = self.validated_config.get("secondary_managed_ap_locations")
 
         if self.validated_config.get("rolling_ap_upgrade"):


### PR DESCRIPTION
## Description
Bug fix in provision workflow manager 
Problem: The provision workflow mandates the dynamic interfaces parameter incorrectly
solution have removed the mandatory terms for the dynamic interfaces

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

