### PR TITLE
Corrected the misleading documentation and handled error for non-existing fabric site

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -13,10 +13,10 @@ DOCUMENTATION = r"""
 module: sda_fabric_devices_workflow_manager
 short_description: Manage SDA fabric devices in Cisco Catalyst Center.
 description:
-- Perform operations on SDA fabric devices, including adding, updating, and deleting fabric devices.
-- Manage L2 handoffs for fabric devices, including adding and deleting configurations.
-- Manage L3 handoffs for fabric devices with IP transit, including adding, updating, and deleting configurations.
-- Manage L3 handoffs for fabric devices with SDA transit, including adding, updating, and deleting configurations.
+  - Perform operations on SDA fabric devices, including adding, updating, and deleting fabric devices.
+  - Manage L2 handoffs for fabric devices, including adding and deleting configurations.
+  - Manage L3 handoffs for fabric devices with IP transit, including adding, updating, and deleting configurations.
+  - Manage L3 handoffs for fabric devices with SDA transit, including adding, updating, and deleting configurations.
 version_added: '6.21.0'
 extends_documentation_fragment:
   - cisco.dnac.workflow_manager_params
@@ -26,7 +26,7 @@ options:
   config_verify:
     description: Set to True to verify the Cisco Catalyst Center after applying the playbook config.
     type: bool
-    default: False
+    default: false
   state:
     description: The state of Cisco Catalyst Center after module completion.
     type: str
@@ -34,8 +34,8 @@ options:
     default: merged
   config:
     description:
-    - A list of SDA fabric device configurations associated with fabric sites.
-    - Each entry in the list represents the configurations for devices within a fabric site.
+      - A list of SDA fabric device configurations associated with fabric sites.
+      - Each entry in the list represents the configurations for devices within a fabric site.
     type: list
     elements: dict
     required: true
@@ -46,12 +46,12 @@ options:
         suboptions:
           fabric_name:
             description:
-            - Name of the SDA fabric site.
-            - Mandatory parameter for all operations under fabric_devices.
-            - The fabric site must already be created before configuring devices.
-            - A Fabric Site is composed of networking devices operating in SD-Access Fabric roles.
-            - A fabric site consists of networking devices in SD-Access Fabric roles, including Border Nodes, Control Plane Nodes, and Edge Nodes.
-            - A Fabric sites may also include Fabric Wireless LAN Controllers and Fabric Wireless Access Points.
+              - Name of the SDA fabric site.
+              - Mandatory parameter for all operations under fabric_devices.
+              - The fabric site must already be created before configuring devices.
+              - A Fabric Site is composed of networking devices operating in SD-Access Fabric roles.
+              - A fabric site consists of networking devices in SD-Access Fabric roles, including Border Nodes, Control Plane Nodes, and Edge Nodes.
+              - A Fabric sites may also include Fabric Wireless LAN Controllers and Fabric Wireless Access Points.
             type: str
             required: true
           device_config:
@@ -63,54 +63,54 @@ options:
             suboptions:
               device_ip:
                 description:
-                - IP address of the device to be added to the fabric site.
-                - Mandatory parameter for all operations under fabric_devices.
-                - Device must be provisioned to the site prior to configuration.
+                  - IP address of the device to be added to the fabric site.
+                  - Mandatory parameter for all operations under fabric_devices.
+                  - Device must be provisioned to the site prior to configuration.
                 type: str
                 required: true
               delete_fabric_device:
                 description:
-                - Effective only when the state is deleted.
-                - Set to true to delete the device from the fabric site, or false to retain it.
+                  - Effective only when the state is deleted.
+                  - Set to true to delete the device from the fabric site, or false to retain it.
                 type: bool
               device_roles:
                 description:
-                - Specifies the role(s) of the device within the fabric site.
-                - This parameter is required when adding the device to the fabric site.
-                - The device roles cannot be updated once assigned.
-                - At least one device must be a CONTROL_PLANE_NODE to assign roles to other devices.
-                - Available roles,
-                  - CONTROL_PLANE_NODE - Manages the mapping of endpoint IP addresses to their location
-                                         within the network using LISP, enabling mobility.
-                  - EDGE_NODE - Connects endpoints to the SDA network, handling policy enforcement,
-                                segmentation, and communication with the control plane.
-                  - BORDER_NODE - Acts as the gateway between the fabric and external networks,
-                                  managing traffic entering or exiting the SDA environment.
-                  - WIRELESS_CONTROLLER_NODE - Manages and controls wireless access points and
-                                               devices within the network.
-                - For 'WIRELESS_CONTROLLER_NODE', the check for the provisioning status will be added in 2.3.7.6 SDK.
+                  - Specifies the role(s) of the device within the fabric site.
+                  - This parameter is required when adding the device to the fabric site.
+                  - The device roles cannot be updated once assigned.
+                  - At least one device must be a CONTROL_PLANE_NODE to assign roles to other devices.
+                  - Available roles,
+                    - CONTROL_PLANE_NODE - Manages the mapping of endpoint IP addresses to their location
+                                            within the network using LISP, enabling mobility.
+                    - EDGE_NODE - Connects endpoints to the SDA network, handling policy enforcement,
+                                    segmentation, and communication with the control plane.
+                    - BORDER_NODE - Acts as the gateway between the fabric and external networks,
+                                    managing traffic entering or exiting the SDA environment.
+                    - WIRELESS_CONTROLLER_NODE - Manages and controls wireless access points and
+                                                devices within the network.
+                  - For 'WIRELESS_CONTROLLER_NODE', the check for the provisioning status will be added in 2.3.7.6 SDK.
                 choices: [CONTROL_PLANE_NODE, EDGE_NODE, BORDER_NODE, WIRELESS_CONTROLLER_NODE]
                 type: list
                 elements: str
               route_distribution_protocol:
                 description:
-                - Specifies the Route Distribution Protocol for the Control Plane Device.
-                - The route distribution protocol manages routing information across network segments.
-                - Available protocols,
-                  - LISP_BGP - Location/ID Separation Protocol with a publish-subscribe mechanism
-                               for distributing routing information.
-                  - LISP_PUB_SUB - Location/ID Separation Protocol with BGP, where BGP serves as the control plane
-                                   to advertise and manage routing information within LISP networks.
+                  - Specifies the Route Distribution Protocol for the Control Plane Device.
+                  - The route distribution protocol manages routing information across network segments.
+                  - Available protocols,
+                    - LISP_BGP - Location/ID Separation Protocol with a publish-subscribe mechanism
+                                for distributing routing information.
+                    - LISP_PUB_SUB - Location/ID Separation Protocol with BGP, where BGP serves as the control plane
+                                    to advertise and manage routing information within LISP networks.
                 choices: [LISP_BGP, LISP_PUB_SUB]
                 default: LISP_BGP
                 type: str
               borders_settings:
                 description:
-                - Effective only when the 'device_roles' contains BORDER_NODE.
-                - This parameter is required when adding the device to a fabric site with the `BORDER_NODE` role.
-                - Updates to `borders_settings` are allowed after the initial configuration.
-                - Border type can be Layer2 or Layer3.
-                - Border type can be Layer2 or Layer3, identified based on the presence of L2 Handoff or L3 Handoff with IP or SDA transit.
+                  - Effective only when the 'device_roles' contains BORDER_NODE.
+                  - This parameter is required when adding the device to a fabric site with the `BORDER_NODE` role.
+                  - Updates to `borders_settings` are allowed after the initial configuration.
+                  - Border type can be Layer2 or Layer3.
+                  - Border type can be Layer2 or Layer3, identified based on the presence of L2 Handoff or L3 Handoff with IP or SDA transit.
                 type: dict
                 suboptions:
                   layer3_settings:
@@ -120,201 +120,201 @@ options:
                     suboptions:
                       local_autonomous_system_number:
                         description:
-                        - Identifies the local autonomous system in BGP routing.
-                        - This parameter is required when adding a device with the `BORDER_NODE` role.
-                        - The `local_autonomous_system_number` cannot be updated once set.
-                        - Acceptable range is from 1 to 4,294,967,295.
-                        - Dot notation (1.0 to 65535.65535) is also allowed. For example, 65534.65535.
+                          - Identifies the local autonomous system in BGP routing.
+                          - This parameter is required when adding a device with the `BORDER_NODE` role.
+                          - The `local_autonomous_system_number` cannot be updated once set.
+                          - Acceptable range is from 1 to 4,294,967,295.
+                          - Dot notation (1.0 to 65535.65535) is also allowed. For example, 65534.65535.
                         type: str
                       is_default_exit:
                         description:
-                        - Indicates whether this Border Node serves as the default gateway for traffic exiting the virtual network.
-                        - The `is_default_exit` cannot be updated.
+                          - Indicates whether this Border Node serves as the default gateway for traffic exiting the virtual network.
+                          - The `is_default_exit` cannot be updated.
                         type: bool
                         default: true
                       import_external_routes:
                         description:
-                        - Determines whether routes from external networks are imported into the fabric.
-                        - Enhances security by limiting route usage to internal routes.
-                        - The 'import_external_routes' cannot be updated.
+                          - Determines whether routes from external networks are imported into the fabric.
+                          - Enhances security by limiting route usage to internal routes.
+                          - The 'import_external_routes' cannot be updated.
                         type: bool
                         default: true
                       border_priority:
                         description:
-                        - Sets the preference level for this Border Node when multiple border nodes are present.
-                        - Higher-priority nodes are favored for routing traffic to external networks.
-                        - Acceptable range is from 1 to 9. If not set, the default value is 10.
-                        - This parameter can be updated.
+                          - Sets the preference level for this Border Node when multiple border nodes are present.
+                          - Higher-priority nodes are favored for routing traffic to external networks.
+                          - Acceptable range is from 1 to 9. If not set, the default value is 10.
+                          - This parameter can be updated.
                         type: int
                         default: 10
                       prepend_autonomous_system_count:
                         description:
-                        - Increases the AS path length artificially when advertising routes via BGP.
-                        - It makes the route less attractive to external peers.
-                        - Acceptable range is from 1 to 10. If not set, the default value is 0.
-                        - This parameter can be updated.
+                          - Increases the AS path length artificially when advertising routes via BGP.
+                          - It makes the route less attractive to external peers.
+                          - Acceptable range is from 1 to 10. If not set, the default value is 0.
+                          - This parameter can be updated.
                         type: int
                         default: 0
                   layer3_handoff_ip_transit:
                     description:
-                    - Adds layer 3 handoffs with ip transit in fabric devices.
-                    - Configured when IP traffic is routed from the SDA fabric to external networks.
-                    - If 'layer3_handoff_ip_transit' is set, border type will be considered as Layer3.
+                      - Adds layer 3 handoffs with ip transit in fabric devices.
+                      - Configured when IP traffic is routed from the SDA fabric to external networks.
+                      - If 'layer3_handoff_ip_transit' is set, border type will be considered as Layer3.
                     type: list
                     elements: dict
                     suboptions:
                       transit_network_name:
                         description:
-                        - Network that connects multiple SDA fabrics or networks.
-                        - Required for all operations in L3 Handoff with IP transit.
-                        - It is not possible to update `transit_network_name` after initial configuration.
+                          - Network that connects multiple SDA fabrics or networks.
+                          - Required for all operations in L3 Handoff with IP transit.
+                          - It is not possible to update `transit_network_name` after initial configuration.
                         type: str
                       interface_name:
                         description:
-                        - Refers to the specific network interface in the border device.
-                        - This parameter is required for all operations in L3 Handoff with IP transit.
-                        - This parameter cannot be updated after being set.
+                          - Refers to the specific network interface in the border device.
+                          - This parameter is required for all operations in L3 Handoff with IP transit.
+                          - This parameter cannot be updated after being set.
                         type: str
                       external_connectivity_ip_pool_name:
                         description:
-                        - Denotes the IP address range allocated for communication between the SDA fabric and external networks.
-                        - This parameter is required for adding the L3 Handoff with IP transit.
-                        - The IP pool must be reserved in the fabric site.
-                        - If `external_connectivity_ip_pool_name` is specified, there is no need to set the local and remote addresses.
-                        - Specifying `external_connectivity_ip_pool_name` will automatically configure the local and remote addresses.
-                        - If both are set, `external_connectivity_ip_pool_name` takes precedence.
-                        - Updating IP addresses is not permitted.
+                          - Denotes the IP address range allocated for communication between the SDA fabric and external networks.
+                          - This parameter is required for adding the L3 Handoff with IP transit.
+                          - The IP pool must be reserved in the fabric site.
+                          - If `external_connectivity_ip_pool_name` is specified, there is no need to set the local and remote addresses.
+                          - Specifying `external_connectivity_ip_pool_name` will automatically configure the local and remote addresses.
+                          - If both are set, `external_connectivity_ip_pool_name` takes precedence.
+                          - Updating IP addresses is not permitted.
                         type: str
                       virtual_network_name:
                         description:
-                        - Refers to the logical segmentation of the network, grouping devices into isolated virtual networks.
-                        - Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
+                          - Refers to the logical segmentation of the network, grouping devices into isolated virtual networks.
+                          - Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
                         type: str
                       vlan_id:
                         description:
-                        - Unique identifier assigned to a Virtual Local Area Network (VLAN).
-                        - Should be unique across the entire fabric site settings.
-                        - The 'vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
-                        - Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
-                        - This parameter cannot be updated once set.
+                          - Unique identifier assigned to a Virtual Local Area Network (VLAN).
+                          - Should be unique across the entire fabric site settings.
+                          - The 'vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
+                          - Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
+                          - This parameter cannot be updated once set.
                         type: int
                       tcp_mss_adjustment:
                         description:
-                        - Allows the modification of the Maximum Segment Size in TCP packets.
-                        - The 'tcp_mss_adjustment' can be set from 500 to 1440.
-                        - This parameter can be updated after being initially set.
+                          - Allows the modification of the Maximum Segment Size in TCP packets.
+                          - The 'tcp_mss_adjustment' can be set from 500 to 1440.
+                          - This parameter can be updated after being initially set.
                         type: int
                       local_ip_address:
                         description:
-                        - IP address assigned to a device's interface within the fabric.
-                        - The 'local_ip_address' is for IPv4.
-                        - Both 'local_ip_address' and 'remote_ip_address' must fall within the same subnet.
-                        - Either local and remote addresses or `external_connectivity_ip_pool_name` is required.
-                        - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
-                          `external_connectivity_ip_pool_name` takes precedence.
+                          - IP address assigned to a device's interface within the fabric.
+                          - The 'local_ip_address' is for IPv4.
+                          - Both 'local_ip_address' and 'remote_ip_address' must fall within the same subnet.
+                          - Either local and remote addresses or `external_connectivity_ip_pool_name` is required.
+                          - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
+                            `external_connectivity_ip_pool_name` takes precedence.
                         type: str
                       remote_ip_address:
                         description:
-                        - IP address of a device located outside the fabric network, often used for BGP peering.
-                        - The 'remote_ip_address' is for IPv4.
-                        - Both 'local_ip_address' and 'remote_ip_address' must fall within the same subnet.
-                        - Either local and remote addresses or `external_connectivity_ip_pool_name` is required.
-                        - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
-                          `external_connectivity_ip_pool_name` takes precedence.
+                          - IP address of a device located outside the fabric network, often used for BGP peering.
+                          - The 'remote_ip_address' is for IPv4.
+                          - Both 'local_ip_address' and 'remote_ip_address' must fall within the same subnet.
+                          - Either local and remote addresses or `external_connectivity_ip_pool_name` is required.
+                          - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
+                            `external_connectivity_ip_pool_name` takes precedence.
                         type: str
                       local_ipv6_address:
                         description:
-                        - IP address assigned to a device's interface within the fabric.
-                        - The local_ipv6_address is for IPv6.
-                        - Both 'local_ipv6_address' and 'remote_ipv6_address' must fall within the same subnet.
-                        - If 'remote_ipv6_address' is provided, then 'local_ipv6_address' is required.
-                        - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
-                          `external_connectivity_ip_pool_name` takes precedence.
+                          - IP address assigned to a device's interface within the fabric.
+                          - The local_ipv6_address is for IPv6.
+                          - Both 'local_ipv6_address' and 'remote_ipv6_address' must fall within the same subnet.
+                          - If 'remote_ipv6_address' is provided, then 'local_ipv6_address' is required.
+                          - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
+                            `external_connectivity_ip_pool_name` takes precedence.
                         type: str
                       remote_ipv6_address:
                         description:
-                        - IP address of a device located outside the fabric network, often used for BGP peering.
-                        - The 'remote_ipv6_address' is for IPv6.
-                        - Both 'local_ipv6_address' and 'remote_ipv6_address' must fall within the same subnet.
-                        - If 'local_ipv6_address' is provided, then 'remote_ipv6_address' is required.
-                        - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
-                          `external_connectivity_ip_pool_name` takes precedence.
+                          - IP address of a device located outside the fabric network, often used for BGP peering.
+                          - The 'remote_ipv6_address' is for IPv6.
+                          - Both 'local_ipv6_address' and 'remote_ipv6_address' must fall within the same subnet.
+                          - If 'local_ipv6_address' is provided, then 'remote_ipv6_address' is required.
+                          - If local and remote addresses are provided with 'external_connectivity_ip_pool_name',
+                            `external_connectivity_ip_pool_name` takes precedence.
                         type: str
                   layer3_handoff_sda_transit:
                     description:
-                    - Adds layer 3 handoffs with SDA transit in fabric devices.
-                    - Configured when routing traffic is routed from the SDA fabric to external networks.
-                    - If 'layer3_handoff_sda_transit' is set, border type will be considered as Layer3.
+                      - Adds layer 3 handoffs with SDA transit in fabric devices.
+                      - Configured when routing traffic is routed from the SDA fabric to external networks.
+                      - If 'layer3_handoff_sda_transit' is set, border type will be considered as Layer3.
                     type: dict
                     suboptions:
                       transit_network_name:
                         description:
-                        - Network that connects multiple SDA fabrics or networks.
-                        - This parameter is required for all operations in L3 Handoff with SDA transit.
-                        - The transit_network_name cannot be updated.
+                          - Network that connects multiple SDA fabrics or networks.
+                          - This parameter is required for all operations in L3 Handoff with SDA transit.
+                          - The transit_network_name cannot be updated.
                         type: str
                       affinity_id_prime:
                         description:
-                        - It supersedes the border priority to determine border node preference.
-                        - The lower the relative value of 'affinity_id_prime', the higher the preference.
-                        - Resources with the same affinity ID are treated similarly and affinity_id_decider decides the priority.
-                        - The 'affinity_id_prime' ranges from 0 to 2147483647.
-                        - The 'affinity_id_prime' can be updated.
+                          - It supersedes the border priority to determine border node preference.
+                          - The lower the relative value of 'affinity_id_prime', the higher the preference.
+                          - Resources with the same affinity ID are treated similarly and affinity_id_decider decides the priority.
+                          - The 'affinity_id_prime' ranges from 0 to 2147483647.
+                          - The 'affinity_id_prime' can be updated.
                         type: int
                       affinity_id_decider:
                         description:
-                        - If the 'affinity_id_prime' value is the same, the 'affinity_id_decider' value is used as a tiebreaker.
-                        - The lower the relative value of 'affinity_id_decider', the higher the preference.
-                        - The 'affinity_id_decider' ranges from 0 to 2147483647.
-                        - The 'affinity_id_decider' can be updated.
+                          - If the 'affinity_id_prime' value is the same, the 'affinity_id_decider' value is used as a tiebreaker.
+                          - The lower the relative value of 'affinity_id_decider', the higher the preference.
+                          - The 'affinity_id_decider' ranges from 0 to 2147483647.
+                          - The 'affinity_id_decider' can be updated.
                         type: int
                       connected_to_internet:
                         description:
-                        - Set this true to allow associated site to provide internet access to other sites through SDA.
-                        - Default value is false.
-                        - This parameter can be updated.
+                          - Set this true to allow associated site to provide internet access to other sites through SDA.
+                          - Default value is false.
+                          - This parameter can be updated.
                         type: bool
                         default: false
                       is_multicast_over_transit_enabled:
                         description:
-                        - Set this true to configure native multicast over multiple sites that are connected to an SDA transit.
-                        - Default value is false.
-                        - This parameter can be updated.
+                          - Set this true to configure native multicast over multiple sites that are connected to an SDA transit.
+                          - Default value is false.
+                          - This parameter can be updated.
                         type: bool
                         default: false
                   layer2_handoff:
                     description:
-                    - Adds layer 2 handoffs in fabric devices.
-                    - This parameter cannots be updated.
-                    - Configured while transferring a device's data traffic at Layer 2 (Data Link layer).
-                    - If 'layer2_handoff' is set, the border type will be considered as Layer2.
+                      - Adds layer 2 handoffs in fabric devices.
+                      - This parameter cannots be updated.
+                      - Configured while transferring a device's data traffic at Layer 2 (Data Link layer).
+                      - If 'layer2_handoff' is set, the border type will be considered as Layer2.
                     type: list
                     elements: dict
                     suboptions:
                       interface_name:
                         description:
-                        - Refers to the specific network interface in the border device.
-                        - This parameter is required for all operations in L2 Handoff.
-                        - The 'interface_name' cannot be updated.
+                          - Refers to the specific network interface in the border device.
+                          - This parameter is required for all operations in L2 Handoff.
+                          - The 'interface_name' cannot be updated.
                         type: str
                       internal_vlan_id:
                         description:
-                        - Represents the VLAN identifier used within the fabric for traffic segmentation among devices.
-                        - Should be unique across the entire fabric site settings.
-                        - This parameter is required for all operations in layer2_handoff.
-                        - The 'internal_vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
+                          - Represents the VLAN identifier used within the fabric for traffic segmentation among devices.
+                          - Should be unique across the entire fabric site settings.
+                          - This parameter is required for all operations in layer2_handoff.
+                          - The 'internal_vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
                         type: int
                       external_vlan_id:
                         description:
-                        - Represents to the VLAN identifier used for traffic that exits the fabric to external networks.
-                        - Should be unique across the entire fabric site settings.
-                        - This parameter is required for all operations in 'layer2_handoff'.
-                        - The 'external_vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
+                          - Represents to the VLAN identifier used for traffic that exits the fabric to external networks.
+                          - Should be unique across the entire fabric site settings.
+                          - This parameter is required for all operations in 'layer2_handoff'.
+                          - The 'external_vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
                         type: int
 
 requirements:
-- dnacentersdk >= 2.9.2
-- python >= 3.9
+  - dnacentersdk >= 2.9.2
+  - python >= 3.9
 notes:
   - SDK Method used are
     site_design.SiteDesign.get_sites,

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -103,8 +103,7 @@ options:
                                    to advertise and manage routing information within LISP networks.
                 choices: [LISP_BGP, LISP_PUB_SUB]
                 default: LISP_BGP
-                type: list
-                elements: str
+                type: str
               borders_settings:
                 description:
                 - Effective only when the 'device_roles' contains BORDER_NODE.
@@ -529,7 +528,7 @@ EXAMPLES = r"""
               external_connectivity_ip_pool_name: Reserved_sda_test_1
               virtual_network_name: L3VN1
               vlan_id: 440
-              tcp_mss_adjustment: 2
+              tcp_mss_adjustment: 501
 
 - name: Add L3 Handoff with IP Transit to the SDA fabric device with local and remote network
   cisco.dnac.sda_fabric_devices_workflow_manager:
@@ -2174,6 +2173,12 @@ class FabricDevices(DnacBase):
                     "The provided 'fabric_name' '{fabric_name}' is not valid a fabric site."
                     .format(fabric_name=fabric_name)
                 )
+                if self.params.get("state") == "deleted":
+                    self.log(self.msg, "INFO")
+                    self.result.get("response").append({"msg": self.msg})
+                    self.status = "exited"
+                    return self
+
                 self.log(self.msg, "ERROR")
                 self.status = "failed"
                 return self

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -30,7 +30,7 @@ options:
   state:
     description: The state of Cisco Catalyst Center after module completion.
     type: str
-    choices: [ merged, deleted ]
+    choices: [merged, deleted]
     default: merged
   config:
     description:
@@ -195,7 +195,7 @@ options:
                         - Unique identifier assigned to a Virtual Local Area Network (VLAN).
                         - Should be unique across the entire fabric site settings.
                         - The 'vlan_id' can range from 1 to 4094, excluding 1, 1002-1005, 2046, and 4094.
-                        -  Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
+                        - Either `virtual_network_name` or `vlan_id` is required for all operations in L3 Handoff with IP transit.
                         - This parameter cannot be updated once set.
                         type: int
                       tcp_mss_adjustment:


### PR DESCRIPTION

## Description
Corrected the misleading documentation and handled error for non-existing fabric site

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

