### PR TITLE
Access point power_level var name update issue

### DIFF
--- a/plugins/modules/accesspoint_workflow_manager.py
+++ b/plugins/modules/accesspoint_workflow_manager.py
@@ -3259,6 +3259,7 @@ class Accesspoint(DnacBase):
 
         temp_dtos = {}
         unmatch_count = 0
+        self.keymap["power_level"] = "powerlevel"
         dtos_keys = list(want_radio.keys())
         slot_id_key = "_" + str(current_radio["slot_id"])
         self.log("Comparing keys for slot ID: {}".format(current_radio["slot_id"]), "INFO")
@@ -3289,6 +3290,13 @@ class Accesspoint(DnacBase):
                 elif dto_key == "radio_band":
                     temp_dtos[self.keymap[dto_key]] = want_radio[dto_key]
                     self.log("Radio band set to: {0}".format(want_radio[dto_key]), "INFO")
+                elif dto_key == "power_level":
+                    if want_radio[dto_key] != current_radio[self.keymap[dto_key]]:
+                        temp_dtos[self.keymap[dto_key]] = want_radio[dto_key]
+                        self.log("Unmatched key {0}: current value {1}, desired value {2}"
+                                 .format(dto_key, current_radio[self.keymap[dto_key]],
+                                         want_radio[dto_key]), "INFO")
+                        unmatch_count = unmatch_count + 1
                 else:
                     if want_radio[dto_key] != current_radio[dto_key]:
                         temp_dtos[self.keymap[dto_key]] = want_radio[dto_key]


### PR DESCRIPTION
## Description
CSCwm83940 - IaC2.0 Access Point: Updating Power Level via Ansible is unsuccessful

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

