### PR TITLE
units of measure bug changes

### DIFF
--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -1312,8 +1312,8 @@ class Site(DnacBase):
                                     units_of_measure))
                             self.log("Invalid 'units_of_measure': {0}. Expected 'feet' or 'meters'.".format(units_of_measure), "ERROR")
                     else:
-                        errormsg.append("units_of_measure should not be None or empty")
-                        self.log("Missing 'units_of_measure' in floor entry.", "ERROR")
+                        site[site_type]["units_of_measure"] = "feet"
+                        self.log("Default value assigned for units_of_measure: feet.", "INFO")
 
                 upload_floor_image_path = site.get(site_type, {}).get("upload_floor_image_path")
                 if upload_floor_image_path:


### PR DESCRIPTION
## Description
Modifications for the below bug
[CSCwn27996] -- > [SITE]: The "units_of_measure" parameter not support, but playbook required

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

