### PR TITLE
changes for unit of measure bug

### DIFF
--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -130,7 +130,7 @@ options:
               units_of_measure:
                 description: |
                     Specifies the unit of measurement for floor dimensions, such as 'feet' or 'meters'.
-                    This field was introduced in version 2.3.7.6 and is optional.
+                    This field was introduced in version 2.3.7.6 onwards.
                     default: feet
                 type: str
               upload_floor_image_path:


### PR DESCRIPTION
## Description
Modifications for the below bug
[CSCwn27996] -- > [SITE]: The "units_of_measure" parameter not support, but playbook required

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

