### PR TITLE
Corrected the documentation when the 'borders_settings' is not found in the playbook

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2523,7 +2523,7 @@ class FabricDevices(DnacBase):
         if not borders_settings:
             if not have_border_settings:
                 self.msg = (
-                    "The parameter 'border_settings' is mandatory when the 'device_roles' has 'BORDER_NODE' "
+                    "The parameter 'borders_settings' is mandatory when the 'device_roles' has 'BORDER_NODE' "
                     "for the device {ip}.".format(ip=device_ip)
                 )
                 self.status = "failed"


### PR DESCRIPTION
## Description
Corrected the documentation when the 'borders_settings' is not found in the playbook

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

