### PR TITLE
Changed the check_type from string to str and integer to int in the validate_input function

### DIFF
--- a/plugins/modules/ise_radius_integration_workflow_manager.py
+++ b/plugins/modules/ise_radius_integration_workflow_manager.py
@@ -376,10 +376,10 @@ response_1:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_2: Successful updation of Authentication and Policy Server.
@@ -390,10 +390,10 @@ response_2:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_3: Successful creation/updation of network
@@ -404,10 +404,10 @@ response_3:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 """
 
@@ -459,39 +459,39 @@ class IseRadiusIntegration(DnacBase):
             "authentication_policy_server": {
                 "type": "list",
                 "elements": "dict",
-                "server_type": {"type": 'string', "choices": ["AAA", "ISE"]},
-                "server_ip_address": {"type": 'string'},
-                "shared_secret": {"type": 'string'},
-                "protocol": {"type": 'string', "choices": ["TACACS", "RADIUS", "RADIUS_TACACS"]},
-                "encryption_scheme": {"type": 'string'},
-                "message_authenticator_code_key": {"type": 'string'},
-                "encryption_key": {"type": 'string'},
-                "authentication_port": {"type": 'integer'},
-                "accounting_port": {"type": 'integer'},
-                "retries": {"type": 'integer'},
-                "timeout": {"type": 'integer'},
-                "role": {"type": 'string'},
+                "server_type": {"type": 'str', "choices": ["AAA", "ISE"]},
+                "server_ip_address": {"type": 'str'},
+                "shared_secret": {"type": 'str'},
+                "protocol": {"type": 'str', "choices": ["TACACS", "RADIUS", "RADIUS_TACACS"]},
+                "encryption_scheme": {"type": 'str'},
+                "message_authenticator_code_key": {"type": 'str'},
+                "encryption_key": {"type": 'str'},
+                "authentication_port": {"type": 'int'},
+                "accounting_port": {"type": 'int'},
+                "retries": {"type": 'int'},
+                "timeout": {"type": 'int'},
+                "role": {"type": 'str'},
                 "pxgrid_enabled": {"type": 'bool'},
                 "use_dnac_cert_for_pxgrid": {"type": 'bool'},
                 "cisco_ise_dtos": {
                     "type": 'list',
-                    "user_name": {"type": 'string'},
-                    "password": {"type": 'string'},
-                    "fqdn": {"type": 'string'},
-                    "ip_address": {"type": 'string'},
-                    "description": {"type": 'string'},
-                    "ssh_key": {"type": 'string'},
+                    "user_name": {"type": 'str'},
+                    "password": {"type": 'str'},
+                    "fqdn": {"type": 'str'},
+                    "ip_address": {"type": 'str'},
+                    "description": {"type": 'str'},
+                    "ssh_key": {"type": 'str'},
                 },
                 "external_cisco_ise_ip_addr_dtos": {
                     "type": 'list',
                     "external_cisco_ise_ip_addresses": {
                         "type": 'list',
-                        "external_ip_address": {"type": 'string'},
+                        "external_ip_address": {"type": 'str'},
                     },
-                    "ise_type": {"type": 'string'},
+                    "ise_type": {"type": 'str'},
                 },
                 "trusted_server": {"type": 'bool'},
-                "ise_integration_wait_time": {"type": 'integer'}
+                "ise_integration_wait_time": {"type": 'int'}
             }
         }
 

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -723,10 +723,10 @@ response_1:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_2: Successful updation of SDA fabric devices
@@ -737,10 +737,10 @@ response_2:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_3: Successful deletion of SDA fabric devices
@@ -751,10 +751,10 @@ response_3:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_4: Successful creation L2 Handoff in fabric device
@@ -765,10 +765,10 @@ response_4:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 
@@ -780,10 +780,10 @@ response_5:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 
@@ -795,10 +795,10 @@ response_6:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_7: Successful updation L3 Handoff with SDA transit in fabric device
@@ -809,10 +809,10 @@ response_7:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_8: Successful updation L3 Handoff with SDA transit in fabric device
@@ -823,10 +823,10 @@ response_8:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_9: Successful deletion L3 Handoff with SDA transit in fabric device
@@ -837,10 +837,10 @@ response_9:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_10: Successful creation L3 Handoff with IP transit in fabric device
@@ -851,10 +851,10 @@ response_10:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_11: Successful updation L3 Handoff with IP transit in fabric device
@@ -865,10 +865,10 @@ response_11:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_12: Successful deletion L3 Handoff with IP transit in fabric device
@@ -879,10 +879,10 @@ response_12:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_13: Successful addition of Control Node to the fabric.
@@ -893,15 +893,15 @@ response_13:
   sample: >
     {
       "response": {
-        "endTime": "integer",
-        "lastUpdate": "integer",
-        "status": "string",
-        "startTime": "integer",
-        "version": "integer",
-        "resultLocation": "string",
-        "id": "string"
+        "endTime": "int",
+        "lastUpdate": "int",
+        "status": "str",
+        "startTime": "int",
+        "version": "int",
+        "resultLocation": "str",
+        "id": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 """
 
@@ -951,11 +951,11 @@ class FabricDevices(DnacBase):
         temp_spec = {
             "fabric_devices": {
                 "type": 'dict',
-                "fabric_name": {"type": 'string'},
+                "fabric_name": {"type": 'str'},
                 "device_config": {
                     "type": 'list',
                     "elements": 'dict',
-                    "device_ip": {"type": 'string'},
+                    "device_ip": {"type": 'str'},
                     "device_roles": {
                         "type": 'list',
                         "elements": 'str',
@@ -965,41 +965,41 @@ class FabricDevices(DnacBase):
                         "elements": 'dict',
                         "layer3_settings": {
                             "type": 'dict',
-                            "local_autonomous_system_number": {"type": 'string'},
+                            "local_autonomous_system_number": {"type": 'str'},
                             "is_default_exit": {"type": 'bool'},
                             "import_external_routes": {"type": 'bool'},
-                            "border_priority": {"type": 'integer'},
-                            "prepend_autonomous_system_count": {"type": 'integer'}
+                            "border_priority": {"type": 'int'},
+                            "prepend_autonomous_system_count": {"type": 'int'}
                         },
                         "layer3_handoff_ip_transit": {
                             "type": 'list',
                             "elements": 'dict',
-                            "transit_network_name": {"type": 'string'},
-                            "interface_name": {"type": 'string'},
-                            "external_connectivity_ip_pool_name": {"type": 'string'},
-                            "virtual_network_name": {"type": 'string'},
-                            "vlan_id": {"type": 'integer'},
-                            "tcp_mss_adjustment": {"type": 'integer'},
-                            "local_ip_address": {"type": 'string'},
-                            "remote_ip_address": {"type": 'string'},
-                            "local_ipv6_address": {"type": 'string'},
-                            "remote_ipv6_address": {"type": 'string'},
+                            "transit_network_name": {"type": 'str'},
+                            "interface_name": {"type": 'str'},
+                            "external_connectivity_ip_pool_name": {"type": 'str'},
+                            "virtual_network_name": {"type": 'str'},
+                            "vlan_id": {"type": 'int'},
+                            "tcp_mss_adjustment": {"type": 'int'},
+                            "local_ip_address": {"type": 'str'},
+                            "remote_ip_address": {"type": 'str'},
+                            "local_ipv6_address": {"type": 'str'},
+                            "remote_ipv6_address": {"type": 'str'},
                         },
                         "layer3_handoff_sda_transit": {
                             "type": 'list',
                             "elements": 'dict',
-                            "transit_network_name": {"type": 'string'},
-                            "affinity_id_prime": {"type": 'integer'},
-                            "affinity_id_decider": {"type": 'integer'},
+                            "transit_network_name": {"type": 'str'},
+                            "affinity_id_prime": {"type": 'int'},
+                            "affinity_id_decider": {"type": 'int'},
                             "connected_to_internet": {"type": 'bool'},
                             "is_multicast_over_transit_enabled": {"type": 'bool'}
                         },
                         "layer2_handoff": {
                             "type": 'list',
                             "elements": 'dict',
-                            "interface_name": {"type": 'string'},
-                            "internal_vlan_id": {"type": 'integer'},
-                            "external_vlan_id": {"type": 'integer'}
+                            "interface_name": {"type": 'str'},
+                            "internal_vlan_id": {"type": 'int'},
+                            "external_vlan_id": {"type": 'int'}
                         }
                     }
                 }

--- a/plugins/modules/sda_fabric_transits_workflow_manager.py
+++ b/plugins/modules/sda_fabric_transits_workflow_manager.py
@@ -171,8 +171,8 @@ EXAMPLES = r"""
       transit_type: SDA_LISP_BGP_TRANSIT
       sda_transit_settings:
         control_plane_network_device_ips:
-        - string
-        - string
+        - 10.0.0.1
+        - 10.0.0.2
 
 - name: Create SDA fabric transit of transit_type SDA_LISP_PUB_SUB_TRANSIT
   cisco.dnac.sda_fabric_transits_workflow_manager:
@@ -194,10 +194,10 @@ EXAMPLES = r"""
       sda_transit_settings:
         is_multicast_over_transit_enabled: false
         control_plane_network_device_ips:
-        - string
-        - string
-        - string
-        - string
+        - 10.0.0.1
+        - 10.0.0.2
+        - 10.0.0.3
+        - 10.0.0.4
 
 - name: Update SDA fabric transit of transit_type SDA_LISP_BGP_TRANSIT
   cisco.dnac.sda_fabric_transits_workflow_manager:
@@ -218,8 +218,8 @@ EXAMPLES = r"""
       transit_type: SDA_LISP_BGP_TRANSIT
       sda_transit_settings:
         control_plane_network_device_ips:
-        - string
-        - string
+        - 10.0.0.1
+        - 10.0.0.2
 
 - name: Update the multicast over transit
   cisco.dnac.sda_fabric_transits_workflow_manager:
@@ -260,9 +260,9 @@ EXAMPLES = r"""
       transit_type: SDA_LISP_PUB_SUB_TRANSIT
       sda_transit_settings:
         control_plane_network_device_ips:
-        - string
-        - string
-        - string
+        - 10.0.0.1
+        - 10.0.0.2
+        - 10.0.0.3
 
 - name: Delete SDA fabric transit
   cisco.dnac.sda_fabric_transits_workflow_manager:
@@ -292,10 +292,10 @@ response_1:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_2: Successful updation of SDA fabric transit
@@ -306,10 +306,10 @@ response_2:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 
 # Case_3: Successful deletion of SDA fabric transit
@@ -320,10 +320,10 @@ response_3:
   sample: >
     {
       "response": {
-        "taskId": "string",
-        "url": "string"
+        "taskId": "str",
+        "url": "str"
       },
-      "version": "string"
+      "version": "str"
     }
 """
 
@@ -375,17 +375,17 @@ class FabricTransit(DnacBase):
             "sda_fabric_transits": {
                 "type": 'list',
                 "elements": 'dict',
-                "name": {"type": 'string'},
-                "transit_type": {"type": 'string', "choices": ["IP_BASED_TRANSIT", "SDA_LISP_PUB_SUB_TRANSIT", "SDA_LISP_BGP_TRANSIT"]},
+                "name": {"type": 'str'},
+                "transit_type": {"type": 'str', "choices": ["IP_BASED_TRANSIT", "SDA_LISP_PUB_SUB_TRANSIT", "SDA_LISP_BGP_TRANSIT"]},
                 "ip_transit_settings": {
                     "type": 'dict',
-                    "routing_protocol_name": {"type": 'string', "choices": ["BGP"]},
-                    "autonomous_system_number": {"type": 'integer'}
+                    "routing_protocol_name": {"type": 'str', "choices": ["BGP"]},
+                    "autonomous_system_number": {"type": 'int'}
                 },
                 "sda_transit_settings": {
                     "type": 'dict',
                     "is_multicast_over_transit_enabled": {"type": 'bool'},
-                    "control_plane_network_device_ips": {"type": 'list', "elements": 'string'}
+                    "control_plane_network_device_ips": {"type": 'list', "elements": 'str'}
                 }
             }
         }


### PR DESCRIPTION
## Description
Changed the check_type from string to str and integer to int in the validate_input function
1. Earlier the type in the validate_input for str is given as string.
2. Since the check for a string type in the dnac.py is 'str', I am changing it from string to str.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

