### PR TITLE
return the error attribute instead of an unknown error for invalid cli username

### DIFF
--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2156,17 +2156,17 @@ class DeviceCredential(DnacBase):
                     for item in global_cli_details:
                         if item.get("description") == cli_description and \
                                 item.get("username") == cli_username:
-                            global_cli_details = item
-                    if not global_cli_details:
+                            cli_detail = item
+                    if not cli_detail:
                         self.msg = "The username and description of the CLI credential are invalid"
                         self.status = "failed"
                         return self
 
                 if current_ccc_version_as_int <= self.get_ccc_version_as_int_from_str("2.3.5.3"):
-                    want.get("assign_credentials").update({"cliId": global_cli_details.get("id")})
+                    want.get("assign_credentials").update({"cliId": cli_detail.get("id")})
                 else:
                     want.get("assign_credentials").update({
-                        "cliCredentialsId": {"credentialsId": global_cli_details.get("id")}
+                        "cliCredentialsId": {"credentialsId": cli_detail.get("id")}
                     })
 
         snmp_v2c_read = assign_credentials.get("snmp_v2c_read")
@@ -3342,9 +3342,9 @@ def main():
         ccc_credential.get_have(config).check_return_status()
         if state != "deleted":
             ccc_credential.get_want(config).check_return_status()
-        ccc_credential.get_diff_state_apply[state](config).check_return_status()
-        if config_verify:
-            ccc_credential.verify_diff_state_apply[state](config).check_return_status()
+        # ccc_credential.get_diff_state_apply[state](config).check_return_status()
+        # if config_verify:
+        #     ccc_credential.verify_diff_state_apply[state](config).check_return_status()
 
     module.exit_json(**ccc_credential.result)
 

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -3342,9 +3342,9 @@ def main():
         ccc_credential.get_have(config).check_return_status()
         if state != "deleted":
             ccc_credential.get_want(config).check_return_status()
-        # ccc_credential.get_diff_state_apply[state](config).check_return_status()
-        # if config_verify:
-        #     ccc_credential.verify_diff_state_apply[state](config).check_return_status()
+        ccc_credential.get_diff_state_apply[state](config).check_return_status()
+        if config_verify:
+            ccc_credential.verify_diff_state_apply[state](config).check_return_status()
 
     module.exit_json(**ccc_credential.result)
 


### PR DESCRIPTION
## Description
This PR contain Bug fix : should return the error attribute instead of an unknown error
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

