### PR TITLE
Address the issue of creating the VN and anchored it to site and exte…

### DIFF
--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -646,6 +646,22 @@ class VirtualNetwork(DnacBase):
         return self
 
     def fetch_site_id_from_fabric_id(self, fabric_id):
+        """
+        Fetches the site ID corresponding to a given fabric ID in Cisco Catalyst Center.
+
+        Args:
+            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
+            fabric_id (str): The ID of the fabric for which the site ID needs to be retrieved.
+        Description:
+            - Attempts to fetch the site ID from the fabric site using the provided fabric ID.
+            - If the fabric site lookup fails, it checks if the ID belongs to a fabric zone.
+            - Logs messages at different stages for debugging and error handling.
+            - Uses `execute_get_request` to retrieve fabric site and fabric zone details.
+            - If an error occurs, it logs the error message and sets the operation result accordingly.
+        Returns:
+            str or None: The retrieved site ID if found, otherwise None.
+        """
+
         site_id = None
         self.log("Starting retrieval of site ID from fabric site id: '{0}'.".format(fabric_id), "DEBUG")
 


### PR DESCRIPTION
…nd it to multiple fabric sites without changing the spec and schema and fix the documentation typo as well

## Description

In this commit -

-- Address the issue of creating the VN and anchored it to site and extend it to multiple fabric sites without changing the spec and schema. Although as per the GUI we have to create VN first then anchored it to fabric site and then extend it to multiple fabric sites but with the current code changes you can pass this in the single payload and module will take care of all these operations internally.

-- Fix the issue of deleting INFRA and DEFAULT VN from the Catalyst Center in the sda fabric virtual network workflow manager module as they are not allowed to delete in the GUI since comes by default in the Cat C.

--  Fix the issue of handling of deletion of Anycast gateways extending the Anchored VN having the IP pool name on the main site not on the subscriber site  

--  Fix the issue of deletion of Anchored  Virtual networks extending over the fabric sites  by removing it first from the subscriber sites then followed by the deletion of anchored VN from the main site

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

