### PR TITLE
Solved the issue which deletes the devices along with the transit when we try to delete only the transits

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -4727,9 +4727,9 @@ class FabricDevices(DnacBase):
             layer2_handoff = None
             borders_settings = item.get("borders_settings")
             if borders_settings:
-                layer3_handoff_ip_transit = item.get("layer3_handoff_ip_transit")
-                layer3_handoff_sda_transit = item.get("layer3_handoff_sda_transit")
-                layer2_handoff = item.get("layer2_handoff")
+                layer3_handoff_ip_transit = borders_settings.get("layer3_handoff_ip_transit")
+                layer3_handoff_sda_transit = borders_settings.get("layer3_handoff_sda_transit")
+                layer2_handoff = borders_settings.get("layer2_handoff")
 
             if not (layer3_handoff_ip_transit or layer3_handoff_sda_transit or layer2_handoff):
                 if device_exists:


### PR DESCRIPTION
## Description
Solved the issue which deletes the devices along with the transit when we try to delete only the transits

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

