### PR TITLE
Provision bug for assign site to device fixed

### DIFF
--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -879,7 +879,6 @@ class DnacBase():
 
         device_ip = self.get_device_ips_from_device_ids(device_ids)
         ip_address = list(device_ip.values())[0]
-        self.log(ip_address)
         param = {
             "device": [
                 {

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -897,7 +897,7 @@ class DnacBase():
         param = {
             "device": [
                 {
-                    "ip":ip_address
+                    "ip": ip_address
                 }
             ]
         }

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -895,7 +895,7 @@ class DnacBase():
                     self.result['msg'] = "Successfully assigned device(s) {0} to site {1}.".format(str(device_ids), site_name)
                     self.result['response'] = response.get("executionId")
                     self.log(self.result['msg'], "INFO")
-                return self
+                return True
 
             except Exception as e:
                 self.msg = "Error while assigning device(s) to site: {0}, {1}, {2}".format(site_name,

--- a/plugins/module_utils/dnac.py
+++ b/plugins/module_utils/dnac.py
@@ -877,6 +877,17 @@ class DnacBase():
                 self.msg = "Device(s) can only be assigned to building/floor"
                 self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
+        device_ip = self.get_device_ips_from_device_ids(device_ids)
+        ip_address = list(device_ip.values())[0]
+        self.log(ip_address)
+        param = {
+            "device": [
+                {
+                    "ip":ip_address
+                }
+            ]
+        }
+
         if self.get_ccc_version_as_integer() <= self.get_ccc_version_as_int_from_str("2.3.5.3"):
             try:
                 response = self.dnac_apply['exec'](
@@ -885,7 +896,7 @@ class DnacBase():
                     op_modifies=True,
                     params={
                         "site_id": site_id,
-                        "payload": device_ids
+                        "payload": param
                     },
                 )
 


### PR DESCRIPTION
## Description
CSCwn85376 - [IaC2][Provision]: Site Assignment API Fails for Device Provisioning Across Multiple Sites

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

