### PR TITLE
Added the validation for device_roles when the device is present in the fabric site.

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2468,8 +2468,7 @@ class FabricDevices(DnacBase):
         device_roles = device_details.get("device_roles")
         if not device_roles:
             self.log(
-                "User didn't provide the device roles of the device {ip}..."
-                .format(ip=device_ip)
+                "Device roles not provided for device {ip}.".format(ip=device_ip)
             )
             if have_device_exists:
                 self.log(
@@ -2477,7 +2476,8 @@ class FabricDevices(DnacBase):
                     .format(ip=device_ip)
                 )
                 device_roles = have_device_details.get("deviceRoles")
-            else:
+
+            if not device_roles:
                 self.msg = (
                     "The parameter 'device_roles is mandatory under 'device_config' "
                     "for the device with IP '{ip}'.".format(ip=device_ip)

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2472,7 +2472,7 @@ class FabricDevices(DnacBase):
             )
             if have_device_exists:
                 self.log(
-                    "The details of the device with ip '{ip}' is already present in the Cisco Catalyst Center."
+                    "The device details with ip '{ip}' is already present in the Cisco Catalyst Center."
                     .format(ip=device_ip)
                 )
                 device_roles = have_device_details.get("deviceRoles")

--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2466,6 +2466,26 @@ class FabricDevices(DnacBase):
 
         # Device IP and the Fabric name is mandatory and cannot be fetched from the Cisco Catalyst Center
         device_roles = device_details.get("device_roles")
+        if not device_roles:
+            self.log(
+                "User didn't provide the device roles of the device {ip}..."
+                .format(ip=device_ip)
+            )
+            if have_device_exists:
+                self.log(
+                    "The details of the device with ip '{ip}' is already present in the Cisco Catalyst Center."
+                    .format(ip=device_ip)
+                )
+                device_roles = have_device_details.get("deviceRoles")
+            else:
+                self.msg = (
+                    "The parameter 'device_roles is mandatory under 'device_config' "
+                    "for the device with IP '{ip}'.".format(ip=device_ip)
+                )
+                self.log(str(self.msg), "ERROR")
+                self.status = "failed"
+                return self.check_return_status()
+
         self.log("Device roles provided: {roles}".format(roles=device_roles), "DEBUG")
         if sorted(device_roles) == ["CONTROL_PLANE_NODE", "EDGE_NODE"]:
             self.msg = (


### PR DESCRIPTION
## Description
Added the validation for device_roles when the device is present in the fabric site.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

