### PR TITLE
tweaked the poll timers for checking device reachability

### DIFF
--- a/plugins/modules/sda_host_port_onboarding_workflow_manager.py
+++ b/plugins/modules/sda_host_port_onboarding_workflow_manager.py
@@ -768,7 +768,7 @@ class SDAHostPortOnboarding(DnacBase):
         self.set_operation_result("success", False, self.msg, "INFO")
         return self
 
-    def validate_device_exists_and_reachable(self, ip_address, hostname, max_retries=5):
+    def validate_device_exists_and_reachable(self, ip_address, hostname, max_retries=10):
         """
         Validates whether a device is both present in the Catalysr Center and reachable.
         Args:
@@ -786,7 +786,7 @@ class SDAHostPortOnboarding(DnacBase):
             get_device_list_params = {"hostname": hostname}
 
         # poll_interval = self.params.get('dnac_task_poll_interval', 30)
-        poll_interval = 15
+        poll_interval = 60
 
         for attempt in range(max_retries):
             self.log("Executing 'get_device_list' API call with parameters: {0} (Attempt {1}/{2})".format(


### PR DESCRIPTION
## Description

Currently, the mechanism uses a timer set for 10 seconds, with a maximum of 5 retries.

Tweaked the above timers and max retries to 60 seconds and 10 respectively.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

