### PR TITLE
Added unset option for device credential assignment at Global site

### DIFF
--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -224,7 +224,11 @@ options:
                 description: Old Description. Use this for updating the description.
                 type: str
       assign_credentials_to_site:
-        description: Assign Device Credentials to Site.
+        description:
+        - Assign Device Credentials to Site.
+        - Starting from version 2.3.7.6, all credential parameters are mandatory.
+        - If any parameter is missing, it will automatically inherit the value from the parent site—except for the Global site.
+        - The unset option (passing {}) is only applicable for the Global site and not for other sites.
         type: dict
         suboptions:
           cli_credential:
@@ -2751,7 +2755,7 @@ class DeviceCredential(DnacBase):
 
                 if "Global" in site_names:
                     assign_credentials = self.config[0].get("assign_credentials_to_site")
-                    site_exists, global_site_id  = self.get_site_id("Global")
+                    site_exists, global_site_id = self.get_site_id("Global")
                     cli_credential = assign_credentials.get("cli_credential")
                     snmp_v2c_read = assign_credentials.get("snmp_v2c_read")
                     snmp_v2c_write = assign_credentials.get("snmp_v2c_write")
@@ -2785,28 +2789,28 @@ class DeviceCredential(DnacBase):
 
                     if cli_credential == {}:
                         credential_params.update({
-                                    "cliCredentialsId": {}
-                                })
+                            "cliCredentialsId": {}
+                        })
                     if snmp_v2c_read == {}:
                         credential_params.update({
-                                    "snmpv2cReadCredentialsId": {}
-                                })
+                            "snmpv2cReadCredentialsId": {}
+                        })
                     if snmp_v2c_write == {}:
                         credential_params.update({
-                                    "snmpv2cWriteCredentialsId": {}
-                                })
+                            "snmpv2cWriteCredentialsId": {}
+                        })
                     if https_read == {}:
                         credential_params.update({
-                                    "httpReadCredentialsId": {}
-                                })
+                            "httpReadCredentialsId": {}
+                        })
                     if https_write == {}:
                         credential_params.update({
-                                    "httpWriteCredentialsId": {}
-                                })
+                            "httpWriteCredentialsId": {}
+                        })
                     if snmp_v3 == {}:
                         credential_params.update({
-                                    "snmpv3CredentialsId": {}
-                                })
+                            "snmpv3CredentialsId": {}
+                        })
                     credential_params.update({"id": global_site_id})
                     final_response.append(copy.deepcopy(credential_params))
                 else:

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2714,7 +2714,7 @@ class DeviceCredential(DnacBase):
         Returns:
             self
         """
-        self.log(self.config)
+
         result_assign_credential = self.result.get("response")[0].get("assign_credential")
         credential_params = self.want.get("assign_credentials")
         final_response = []
@@ -2735,7 +2735,6 @@ class DeviceCredential(DnacBase):
         site_ids = self.want.get("site_id")
 
         for site_id in site_ids:
-
             if self.get_ccc_version_as_integer() <= self.get_ccc_version_as_int_from_str("2.3.5.3"):
                 credential_params.update({"site_id": site_id})
                 final_response.append(copy.deepcopy(credential_params))
@@ -2812,12 +2811,11 @@ class DeviceCredential(DnacBase):
                             "snmpv3CredentialsId": {}
                         })
                     credential_params.update({"id": global_site_id})
-                    final_response.append(copy.deepcopy(credential_params))
                 else:
                     credential_params = self.want.get("assign_credentials")
                     credential_params.update({"id": site_id})
-                    final_response.append(copy.deepcopy(credential_params))
 
+                final_response.append(copy.deepcopy(credential_params))
                 response = self.dnac._exec(
                     family="network_settings",
                     function='update_device_credential_settings_for_a_site',


### PR DESCRIPTION
## Description
This PR contains Bug fix for :
Enter input empty but still assign any value to CLI credential

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

