### PR TITLE
 Site Module delete floor regression issue fixed

### DIFF
--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -1260,7 +1260,7 @@ class Site(DnacBase):
                 self.log("Performing floor-specific validations.", "DEBUG")
                 floor_number = site.get(site_type, {}).get("floor_number")
                 if self.compare_dnac_versions(self.get_ccc_version(), "2.3.7.6") >= 0:
-                    if floor_number:
+                    if floor_number or floor_number == 0:
                         self.log("Validating 'floor_number': " + str(floor_number), "DEBUG")
                         if not (isinstance(floor_number, int) and -200 <= floor_number <= 200):
                             errormsg.append("Please enter a valid floor number (-200 to 200)")

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2272,15 +2272,21 @@ class Site(DnacBase):
                     self.log("Checking task details for '{0}' deletion.".format(
                         site_type), "DEBUG")
                     if isinstance(response, str):
+                        self.log("Received Task ID '{0}' for {1}.".format(
+                            response, site_type), "INFO")
                         self.process_site_task_details(
                             response, site_type, site_name_hierarchy
                         )
                     elif isinstance(response, dict):
                         task_id = response.get("response", {}).get("taskId")
+                        self.log("Received Task ID '{0}' for {1}.".format(
+                            task_id, site_type), "INFO")
                         self.process_site_task_details(
                             task_id, site_type, site_name_hierarchy
                         )
                     elif isinstance(response, list) and len(response) > 0:
+                        self.log("Received Task list '{0}' for {1}.".format(
+                            str(response), site_type), "INFO")
                         for each_response in response:
                             task_id = each_response.get("response", {}).get("taskId")
                             self.process_site_task_details(

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2067,11 +2067,10 @@ class Site(DnacBase):
                             if self.status == "success":
                                 self.log("Deleted child floor: {0} with ID: {1}".format(
                                     child_site_name_hierarchy, child_site_id), "INFO")
-                                self.deleted_site_list.append("floor: " + str(child_site_name_hierarchy))
+                                self.deleted_site_list.append("floor: {0}".format(str(child_site_name_hierarchy)))
                             else:
                                 self.log("Unable to delete child floor: {0} with ID: {1}".format(
                                     child_site_name_hierarchy, child_site_id), "DEBUG")
-                                self.site_absent_list.append("floor: " + str(child_site_name_hierarchy))
 
             self.log("Deleting building site: '{0}' with ID: '{1}'".format(
                 site_name_hierarchy, site_id), "INFO")

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2071,6 +2071,7 @@ class Site(DnacBase):
                             else:
                                 self.log("Unable to delete child floor: {0} with ID: {1}".format(
                                     child_site_name_hierarchy, child_site_id), "DEBUG")
+                                self.check_return_status()
 
             self.log("Deleting building site: '{0}' with ID: '{1}'".format(
                 site_name_hierarchy, site_id), "INFO")

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2068,6 +2068,10 @@ class Site(DnacBase):
                             self.log("Deleted child floor: {0} with ID: {1}".format(
                                 child_site_name_hierarchy, child_site_id), "INFO")
                             self.deleted_site_list.append("floor: {0}".format(str(child_site_name_hierarchy)))
+                        else:
+                            self.msg = "Unable to delete child site: {0}".format(child_site_name_hierarchy)
+                            self.set_operation_result("failed", False,
+                                                      self.msg, "ERROR").check_return_status()
 
             self.log("Deleting building site: '{0}' with ID: '{1}'".format(
                 site_name_hierarchy, site_id), "INFO")
@@ -2278,27 +2282,30 @@ class Site(DnacBase):
                     self.log("Checking task details for '{0}' deletion.".format(
                         site_type), "DEBUG")
                     if isinstance(response, str):
-                        self.log("Received Task ID '{0}' for {1}.".format(
-                            response, site_type), "INFO")
-                        task_id = response
-                        self.process_site_task_details(
-                            task_id, site_type, site_name_hierarchy
-                        )
+                        if response:
+                            task_id = response
+                            self.log("Received Task ID '{0}' for {1}.".format(
+                                response, site_type), "INFO")
+                            self.process_site_task_details(
+                                task_id, site_type, site_name_hierarchy
+                            )
                     elif isinstance(response, dict):
                         task_id = response.get("response", {}).get("taskId")
-                        self.log("Received Task ID '{0}' for {1}.".format(
-                            task_id, site_type), "INFO")
-                        self.process_site_task_details(
-                            task_id, site_type, site_name_hierarchy
-                        )
-                    elif isinstance(response, list) and len(response) > 0:
+                        if task_id:
+                            self.log("Received Task ID '{0}' for {1}.".format(
+                                task_id, site_type), "INFO")
+                            self.process_site_task_details(
+                                task_id, site_type, site_name_hierarchy
+                            )
+                    elif isinstance(response, list):
                         self.log("Received Task list '{0}' for {1}.".format(
                             str(response), site_type), "INFO")
                         for each_response in response:
                             task_id = each_response.get("response", {}).get("taskId")
-                            self.process_site_task_details(
-                                task_id, site_type, site_name_hierarchy
-                            )
+                            if task_id:
+                                self.process_site_task_details(
+                                    task_id, site_type, site_name_hierarchy
+                                )
 
         return self
 

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2326,9 +2326,11 @@ class Site(DnacBase):
                                                                        site_name_hierarchy)
             self.get_task_status_from_task_by_id(
                 task_id, task_name, None, success_message, progress_msg)
-            self.log("Adding to deleted site list: {0}: {1}".format(
-                site_type, site_name_hierarchy), "DEBUG")
-            self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
+
+            if self.status == "success":
+                self.log("Adding to deleted site list: {0}: {1}".format(
+                    site_type, site_name_hierarchy), "DEBUG")
+                self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
 
         return self
 

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2321,7 +2321,7 @@ class Site(DnacBase):
                         self.msg = "Error response for 'deletes_an_area' task: {0}".format(task_details.get('failureReason'))
                         self.log(self.msg, "ERROR")
                         self.set_operation_result("failed", False, self.msg,
-                                                    "ERROR", task_details).check_return_status()
+                                                  "ERROR", task_details).check_return_status()
                         break
                 elif site_type == "building":
                     if task_details.get("progress") == "Group is deleted successfully":
@@ -2335,7 +2335,7 @@ class Site(DnacBase):
                         self.msg = "Error response for 'deletes_building' task: {0}".format(task_details.get('failureReason'))
                         self.log(self.msg, "ERROR")
                         self.set_operation_result("failed", False, self.msg,
-                                                    "ERROR", task_details).check_return_status()
+                                                  "ERROR", task_details).check_return_status()
                         break
                 else:
                     if task_details.get("progress") == "NCMP00150: Service domain is deleted successfully":
@@ -2345,7 +2345,7 @@ class Site(DnacBase):
                     elif task_details.get("failureReason"):
                         self.msg = "Error response for 'deletes_an_floor' task: {0}".format(task_details.get('failureReason'))
                         self.set_operation_result("failed", False, self.msg, "ERROR",
-                                                    task_details).check_return_status()
+                                                  task_details).check_return_status()
                         break
         return self
 

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2269,18 +2269,18 @@ class Site(DnacBase):
                     elif site_type == "building":
                         response = self.delete_building(site_name_hierarchy, site_id)
 
+                    self.log("Checking task details for '{0}' deletion.".format(
+                        site_type), "DEBUG")
                     if isinstance(response, str):
                         self.process_site_task_details(
                             response, site_type, site_name_hierarchy
                         )
-
-                    if isinstance(response, dict):
+                    elif isinstance(response, dict):
                         task_id = response.get("response", {}).get("taskId")
                         self.process_site_task_details(
                             task_id, site_type, site_name_hierarchy
                         )
-
-                    if isinstance(response, list) and len(response) > 0:
+                    elif isinstance(response, list) and len(response) > 0:
                         for each_response in response:
                             task_id = each_response.get("response", {}).get("taskId")
                             self.process_site_task_details(
@@ -2291,7 +2291,7 @@ class Site(DnacBase):
 
     def process_site_task_details(self, task_id, site_type, site_name_hierarchy):
         """
-        This function used to process the task and return as self with task status and details.
+        Processes the task details based on the given task ID and updates the deleted site list.
 
         Parameters:
             self (object): An instance of a class used for interacting with Cisco Catalyst Center.
@@ -2302,8 +2302,6 @@ class Site(DnacBase):
         Returns:
             self (obj): contains status message of task
 
-        Description:
-            This function used to process the task details by task ID.
         """
         if task_id:
             if site_type == "area":
@@ -2316,10 +2314,14 @@ class Site(DnacBase):
                 task_name = "deletes_an_floor"
                 progress_msg = "NCMP00150: Service domain is deleted successfully"
 
+            self.log("Processing task for {0}: {1}".format(site_type,
+                                                           site_name_hierarchy), "DEBUG")
             success_message = "{0} '{1}' deleted successfully.".format(site_type.title(),
                                                                        site_name_hierarchy)
             self.get_task_status_from_task_by_id(
                 task_id, task_name, None, success_message, progress_msg)
+            self.log("Adding to deleted site list: {0}: {1}".format(
+                site_type, site_name_hierarchy), "DEBUG")
             self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
 
         return self

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2063,15 +2063,11 @@ class Site(DnacBase):
                         if del_task_id:
                             success_msg = "Deleted floor: {0}. Task Id: {1}".format(
                                 child_site_name_hierarchy, del_task_id)
-                            self.get_task_status_from_tasks_by_id(del_task_id, "delete_floor", success_msg)
-                            if self.status == "success":
-                                self.log("Deleted child floor: {0} with ID: {1}".format(
-                                    child_site_name_hierarchy, child_site_id), "INFO")
-                                self.deleted_site_list.append("floor: {0}".format(str(child_site_name_hierarchy)))
-                            else:
-                                self.log("Unable to delete child floor: {0} with ID: {1}".format(
-                                    child_site_name_hierarchy, child_site_id), "DEBUG")
-                                self.check_return_status()
+                            self.get_task_status_from_tasks_by_id(
+                                del_task_id, "delete_floor", success_msg).check_return_status()
+                            self.log("Deleted child floor: {0} with ID: {1}".format(
+                                child_site_name_hierarchy, child_site_id), "INFO")
+                            self.deleted_site_list.append("floor: {0}".format(str(child_site_name_hierarchy)))
 
             self.log("Deleting building site: '{0}' with ID: '{1}'".format(
                 site_name_hierarchy, site_id), "INFO")

--- a/plugins/modules/site_workflow_manager.py
+++ b/plugins/modules/site_workflow_manager.py
@@ -2306,47 +2306,22 @@ class Site(DnacBase):
             This function used to process the task details by task ID.
         """
         if task_id:
-            while True:
-                task_details = self.get_task_details(task_id)
+            if site_type == "area":
+                task_name = "deletes_an_area"
+                progress_msg = "Group is deleted successfully"
+            elif site_type == "building":
+                task_name = "deletes_building"
+                progress_msg = "Group is deleted successfully"
+            else:
+                task_name = "deletes_an_floor"
+                progress_msg = "NCMP00150: Service domain is deleted successfully"
 
-                if site_type == "area":
-                    if task_details.get("progress") == "Group is deleted successfully":
-                        self.msg = "Area '{0}' deleted successfully.".format(site_name_hierarchy)
-                        self.log(self.msg, "INFO")
-                        self.result['changed'] = True
-                        self.result['response'] = task_details
-                        self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
-                        break
-                    elif task_details.get("failureReason"):
-                        self.msg = "Error response for 'deletes_an_area' task: {0}".format(task_details.get('failureReason'))
-                        self.log(self.msg, "ERROR")
-                        self.set_operation_result("failed", False, self.msg,
-                                                  "ERROR", task_details).check_return_status()
-                        break
-                elif site_type == "building":
-                    if task_details.get("progress") == "Group is deleted successfully":
-                        self.msg = "Building '{0}' deleted successfully.".format(site_name_hierarchy)
-                        self.log(self.msg, "INFO")
-                        self.result['changed'] = True
-                        self.result['response'] = task_details
-                        self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
-                        break
-                    elif task_details.get("failureReason"):
-                        self.msg = "Error response for 'deletes_building' task: {0}".format(task_details.get('failureReason'))
-                        self.log(self.msg, "ERROR")
-                        self.set_operation_result("failed", False, self.msg,
-                                                  "ERROR", task_details).check_return_status()
-                        break
-                else:
-                    if task_details.get("progress") == "NCMP00150: Service domain is deleted successfully":
-                        self.log("Area site '{0}' deleted successfully.".format(site_name_hierarchy), "INFO")
-                        self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
-                        break
-                    elif task_details.get("failureReason"):
-                        self.msg = "Error response for 'deletes_an_floor' task: {0}".format(task_details.get('failureReason'))
-                        self.set_operation_result("failed", False, self.msg, "ERROR",
-                                                  task_details).check_return_status()
-                        break
+            success_message = "{0} '{1}' deleted successfully.".format(site_type.title(),
+                                                                       site_name_hierarchy)
+            self.get_task_status_from_task_by_id(
+                task_id, task_name, None, success_message, progress_msg)
+            self.deleted_site_list.append(str(site_type) + ": " + str(site_name_hierarchy))
+
         return self
 
     def verify_diff_merged(self, config):


### PR DESCRIPTION
## Description
CSCwo11889 - IaC INTG:REGR:DAILYSANITY: Sites deletion broken, trying to double delete floors.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

