### PR TITLE
Address the issue of create large number of anycast gateways and upda…

### DIFF
--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -1545,7 +1545,11 @@ class FabricSitesZones(DnacBase):
 
             payload = {
                 "id": site_id,
-                "payload": telemetry_settings
+                "wiredDataCollection": telemetry_settings.get("wiredDataCollection"),
+                "wirelessTelemetry": telemetry_settings.get("wirelessTelemetry"),
+                "snmpTraps": telemetry_settings.get("snmpTraps"),
+                "syslogs": telemetry_settings.get("syslogs"),
+                "applicationVisibility": telemetry_settings.get("applicationVisibility")
             }
             task_name = "set_telemetry_settings_for_a_site"
             task_id = self.get_taskid_post_api_call("network_settings", task_name, payload)


### PR DESCRIPTION
…te the params for the set_telemetry_settings_for_a_site api

## Description
Fix the issue of --
-- Create large number of anycast gateways at a time to make the limit to 20 only.
-- Also update the payload params for the set_telemetry_settings_for_a_site api

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

