### PR TITLE
Fixed the issue with 'is_default_exit' while re-running the same config

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -2664,13 +2664,12 @@ class FabricDevices(DnacBase):
                     is_default_exit = True
             else:
                 if have_layer3_settings:
-                    if is_default_exit != have_layer3_settings.get("importExternalRoutes"):
+                    if is_default_exit != have_layer3_settings.get("isDefaultExit"):
                         self.msg = (
                             "The parameter 'is_default_exit' under 'layer3_settings' should not be "
                             "updated for the device with IP '{ip}'.".format(ip=device_ip)
                         )
-                        self.status = "failed"
-                        return self.check_return_status()
+                        self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
             import_external_routes = layer3_settings.get("import_external_routes")
             if import_external_routes is None:


### PR DESCRIPTION
## Description
How to reproduce - Provision a fabric device in the fabric site (CP, BN, EN) with the 'is_default_exit' as true in the border_settings.
While re-running the config again, we are getting the error saying - "The parameter 'is_default_exit' under 'layer3_settings' should not be updated for the device with IP '204.1.2.2'.",

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

