### PR TITLE
Fix the issue of reconfiguring the fabric sites and enhance the conso…

### DIFF
--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -1297,6 +1297,9 @@ class FabricSitesZones(DnacBase):
             success_msg = "Authentication profile for the site '{0}' updated successfully in the Cisco Catalyst Center".format(site_name)
             self.log(success_msg, "DEBUG")
             self.get_task_status_from_tasks_by_id(task_id, task_name, success_msg)
+            if profile_update_params[0].get("authenticationProfileName") == "Low Impact":
+                site_name += " having preAuthAcl configuration "
+
             self.update_auth_profile.append(site_name)
 
         except Exception as e:
@@ -1401,10 +1404,7 @@ class FabricSitesZones(DnacBase):
             result_msg_list.append(pending_event_msg)
 
         if self.update_auth_profile:
-            update_auth_msg = (
-                "Authentication profile template for site(s) '{0}' updated successfully in Cisco Catalyst "
-                "Center.".format(self.update_auth_profile)
-            )
+            update_auth_msg = "Authentication profile template for site(s) '{0}' updated successfully in Catalyst Center.".format(self.update_auth_profile)
             result_msg_list.append(update_auth_msg)
 
         if self.no_update_profile:
@@ -1718,6 +1718,46 @@ class FabricSitesZones(DnacBase):
 
         return obj
 
+    def reconfigure_the_fabric_site(self, site_name, fabric_id):
+        """
+        Reconfigures the fabric site by applying any pending fabric events for the given site in Cisco Catalyst Center.
+
+        Args:
+            self (object): An instance of a class used for interacting with Cisco Catalyst Center.
+            site_name (str): The name of the site for which to reconfigure the fabric.
+            fabric_id (str): The unique identifier of the fabric associated with the site.
+
+        Returns:
+            self (object): Returns the current instance of the class (self), updated with the result of the operation.
+
+        Description:
+            This method checks if the Cisco Catalyst Center (CCC) version supports pending fabric event reconfiguration
+            (only versions >= 2.3.7.9). If supported, it retrieves and applies all pending fabric events for the specified site
+            and fabric ID. It logs each step of the process and handles exceptions gracefully.
+        """
+
+        try:
+            if not self.compare_dnac_versions(self.get_ccc_version(), "2.3.7.9") >= 0:
+                self.log("Reconfigure the fabric pending events start supporting from 2.3.7.9 onwards only.", "WARNING")
+                return self
+
+            self.log("Checking for pending fabric events on site '{0}' in Cisco Catalyst Center.".format(site_name), "DEBUG")
+            pending_events_map = self.get_all_pending_events_ids(site_name, fabric_id)
+            if not pending_events_map:
+                self.log("There is no pending fabric event present for the site {0}".format(site_name), "INFO")
+
+            for event_detail, event_id in pending_events_map.items():
+                self.log("Applying the pending fabric event {0} for the site {1}".format(event_detail, site_name), "DEBUG")
+                self.apply_pending_fabric_events(event_detail, event_id, fabric_id, site_name).check_return_status()
+                self.pending_fabric_event.append(event_detail + " for site " + site_name)
+                self.log("Pending fabric events get applied successfully to the site {0}".format(site_name), "INFO")
+
+        except Exception as e:
+            self.msg = "An exception occured while applying the reconfiguring the fabric site {0}: {1}".format(site_name, str(e))
+            self.set_operation_result("failed", False, self.msg, "ERROR")
+
+        return self
+
     def get_diff_merged(self, config):
         """
         Creates, updates, or deletes fabric sites and zones based on the provided configuration, and manages
@@ -1792,8 +1832,14 @@ class FabricSitesZones(DnacBase):
                     self.log("Starting the process of making site {0} as fabric site...".format(site_name), "DEBUG")
                     self.create_fabric_site(site).check_return_status()
                 else:
-                    self.log("Checking whether the given fabric site {0} needs update or not.".format(site_name), "DEBUG")
+                    self.log("Checking whether the given fabric site {0} needs to be reconfigire or not.".format(site_name), "DEBUG")
+                    pending_events = site.get("apply_pending_events")
                     site_in_ccc = self.get_fabric_site_detail(site_name, site_id)
+                    if pending_events:
+                        fabric_id = site_in_ccc.get("id")
+                        self.reconfigure_the_fabric_site(site_name, fabric_id).check_return_status()
+
+                    self.log("Checking whether the given fabric site {0} needs update or not.".format(site_name), "DEBUG")
                     require_update = self.fabric_site_needs_update(site, site_in_ccc)
                     if require_update:
                         self.update_fabric_site(site, site_in_ccc).check_return_status()
@@ -1807,9 +1853,14 @@ class FabricSitesZones(DnacBase):
                     self.log("Starting the process of making site {0} as fabric zone...".format(site_name), "DEBUG")
                     self.create_fabric_zone(site).check_return_status()
                 else:
-                    self.log("Checking whether the given fabric zone {0} needs update or not.".format(site_name), "DEBUG")
+                    self.log("Checking whether the given fabric zone {0} needs to be reconfigire or not.".format(site_name), "DEBUG")
+                    pending_events = site.get("apply_pending_events")
                     zone_in_ccc = self.get_fabric_zone_detail(site_name, site_id)
+                    if pending_events:
+                        fabric_id = zone_in_ccc.get("id")
+                        self.reconfigure_the_fabric_site(site_name, fabric_id).check_return_status()
 
+                    self.log("Checking whether the given fabric zone {0} needs update or not.".format(site_name), "DEBUG")
                     if auth_profile and auth_profile != zone_in_ccc.get("authenticationProfileName"):
                         self.log(
                             "Authentication profile '{0}' does not match the profile '{1}' in Cisco Catalyst Center "
@@ -1819,32 +1870,6 @@ class FabricSitesZones(DnacBase):
                     else:
                         self.no_update_zone.append(site_name)
                         self.log("Fabric zone '{0}' already present and does not need any update in the Cisco Catalyst Center.".format(site_name), "INFO")
-
-            # Check if there is any pending fabric event on this site and if it is then reconfigure the fabric sites
-            pending_events = site.get("apply_pending_events")
-            if pending_events:
-                if self.compare_dnac_versions(self.get_ccc_version(), "2.3.7.9") >= 0:
-                    self.log("Checking for pending fabric events on site '{0}' in Cisco Catalyst Center.".format(site_name), "DEBUG")
-                    # With the given site id collect the fabric site/zone id
-                    if fabric_type == "fabric_site":
-                        site_detail = self.get_fabric_site_detail(site_name, site_id)
-                        fabric_id = site_detail.get("id")
-                    else:
-                        zone_detail = self.get_fabric_zone_detail(site_name, site_id)
-                        fabric_id = zone_detail.get("id")
-
-                    pending_events_map = self.get_all_pending_events_ids(site_name, fabric_id)
-
-                    if not pending_events_map:
-                        self.log("There is no pending fabric event present for the site {0}".format(site_name), "INFO")
-
-                    for event_detail, event_id in pending_events_map.items():
-                        self.log("Applying the pending fabric event {0} for the site {1}".format(event_detail, site_name), "DEBUG")
-                        self.apply_pending_fabric_events(event_detail, event_id, fabric_id, site_name).check_return_status()
-                        self.pending_fabric_event.append(event_detail + " for site " + site_name)
-                        self.log("Pending fabric events get applied successfully to the site {0}".format(site_name), "INFO")
-                else:
-                    self.log("Reconfigure the fabric pending events start supporting from 2.3.7.9 onwards only.", "WARNING")
 
             # Updating/customising the default parameters for authentication profile template
             if site.get("update_authentication_profile"):

--- a/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
+++ b/plugins/modules/sda_fabric_sites_zones_workflow_manager.py
@@ -1749,7 +1749,6 @@ class FabricSitesZones(DnacBase):
                     " Current version: {0}".format(current_version),
                     "WARNING"
                 )
-                self.log("Reconfigure the fabric pending events start supporting from 2.3.7.9 onwards only.", "WARNING")
                 return self
 
             self.log("Checking for pending fabric events on site '{0}' with fabric ID '{1} in Catalyst Center.".format(site_name, fabric_id), "DEBUG")

--- a/tests/unit/modules/dnac/test_sda_fabric_sites_zones_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_sites_zones_workflow_manager.py
@@ -104,12 +104,11 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
                 self.test_data.get("get_site_details_2"),
                 self.test_data.get("get_wired_data_collection_details_enable"),
                 self.test_data.get("get_fabric_site_details"),
-                self.test_data.get("response_get_task_id_success_update_fabric_site"),
-                self.test_data.get("response_get_task_status_by_id_success_update_fabric_site"),
-                self.test_data.get("get_fabric_site_details"),
                 self.test_data.get("response_get_pending_fabric_events"),
                 self.test_data.get("response_get_task_id_success_apply_pending_event"),
-                self.test_data.get("response_get_task_status_by_id_success_apply_pending_event")
+                self.test_data.get("response_get_task_status_by_id_success_apply_pending_event"),
+                self.test_data.get("response_get_task_id_success_update_fabric_site"),
+                self.test_data.get("response_get_task_status_by_id_success_update_fabric_site")
             ]
 
         elif "create_fabric_zone" in self._testMethodName:


### PR DESCRIPTION
…le message while updating the authentication profile with Low Impact

## Description
Please include a summary of the changes and the related issue. Also, include relevant motivation and context.

Fix the following issue -- 

-- Reconfigure the fabric site by applying pending fabric events
-- pre_auth_acl should not be applied to authentication_profiles other than "Low Impact"


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

