### PR TITLE
Enhance the log message when ip pool is not reserve at this site.

### DIFF
--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -2723,7 +2723,7 @@ class VirtualNetwork(DnacBase):
             is_pool_exist = self.is_ip_pool_exist(ip_pool_name, site_id)
             if state == "deleted" and not is_pool_exist:
                 self.log(
-                    "Given Reserve pool '{0}' already deleted from the fabric site '{1}'."
+                    "The reserved IP pool '{0}' has already been deleted from the fabric site '{1}'."
                     .format(ip_pool_name, site_name), "INFO"
                 )
                 continue
@@ -2737,8 +2737,9 @@ class VirtualNetwork(DnacBase):
                 anchored_fabric_id = vn_details_in_ccc.get("anchoredSiteId")
                 if not anchored_fabric_id:
                     self.msg = (
-                        "The virtual network '{0}' is not anchored to any site for the reserve IP pool '{1}' "
-                        "in Cisco Catalyst Center.".format(vn_name, ip_pool_name)
+                        "The virtual network '{0}' is not anchored to any site for the reserved IP pool '{1}' in "
+                        "Cisco Catalyst Center. Please ensure the virtual network is properly configured with site anchoring."
+                        .format(vn_name, ip_pool_name)
                     )
                     self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
@@ -3539,7 +3540,7 @@ class VirtualNetwork(DnacBase):
                 "to depict the idempotency behaviour.".format(ip_pool_name), "DEBUG"
             )
             if not is_pool_exist:
-                self.log("Given ip pool '{0}' is not present in Cisco Catalyst Center.".format(ip_pool_name), "INFO")
+                self.log("IP pool '{0}' is not present in Cisco Catalyst Center.".format(ip_pool_name), "INFO")
                 self.absent_anycast_gateways.append(unique_anycast)
                 continue
 

--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -2040,9 +2040,8 @@ class VirtualNetwork(DnacBase):
             )
             response = response.get("response")
             self.log("Received API response from 'get_anycast_gateways' for the IP Pool '{0}': {1}".format(ip_pool_name, str(response)), "DEBUG")
-
             if not response:
-                self.log("There is no reserve ip pool '{0}' present in the Cisco Catalyst Center system.".format(ip_pool_name), "INFO")
+                self.log("There is no gateway '{0}' present in the Cisco Catalyst Center system.", "INFO")
                 return None
 
             self.log("Returning Anycast Gateway details for IP Pool '{0}': {1}".format(ip_pool_name, str(response[0])), "INFO")
@@ -2722,6 +2721,12 @@ class VirtualNetwork(DnacBase):
                 self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
             is_pool_exist = self.is_ip_pool_exist(ip_pool_name, site_id)
+            if state == "deleted" and not is_pool_exist:
+                self.log(
+                    "Given Reserve pool '{0}' already deleted from the fabric site '{1}'."
+                    .format(ip_pool_name, site_name), "INFO"
+                )
+                continue
 
             if not is_pool_exist:
                 self.log(
@@ -2732,8 +2737,8 @@ class VirtualNetwork(DnacBase):
                 anchored_fabric_id = vn_details_in_ccc.get("anchoredSiteId")
                 if not anchored_fabric_id:
                     self.msg = (
-                        "There is no reserve ip pool '{0}' present in the Cisco Catalyst Center."
-                        .format(ip_pool_name)
+                        "The virtual network '{0}' is not anchored to any site for the reserve IP pool '{1}' "
+                        "in Cisco Catalyst Center.".format(vn_name, ip_pool_name)
                     )
                     self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 
@@ -3528,6 +3533,16 @@ class VirtualNetwork(DnacBase):
 
             # Collect the gateway id with combination of vn_name, ip_pool_name and fabric id
             unique_anycast = vn_name + "_" + ip_pool_name + "_" + site_name
+            is_pool_exist = self.is_ip_pool_exist(ip_pool_name, site_id)
+            self.log(
+                "Checking if given ip pool '{0}' already deleted from the Cisco Catalyst Center "
+                "to depict the idempotency behaviour.".format(ip_pool_name), "DEBUG"
+            )
+            if not is_pool_exist:
+                self.log("Given ip pool '{0}' is not present in Cisco Catalyst Center.".format(ip_pool_name), "INFO")
+                self.absent_anycast_gateways.append(unique_anycast)
+                continue
+
             anycast_details_in_ccc = self.get_anycast_gateway_details(vn_name, ip_pool_name, fabric_id)
 
             if not anycast_details_in_ccc:
@@ -3536,7 +3551,6 @@ class VirtualNetwork(DnacBase):
                 continue
 
             gateway_id = anycast_details_in_ccc.get("id")
-
             self.log(
                 "Checking if Anycast Gateway '{0}' is associated with an anchored VN."
                 "If it is, sites extending the anchored VN will be deleted first, then the gateway "

--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -2732,7 +2732,7 @@ class VirtualNetwork(DnacBase):
                 anchored_fabric_id = vn_details_in_ccc.get("anchoredSiteId")
                 if not anchored_fabric_id:
                     self.msg = (
-                        "There is no reserve ip pool '{0}' present in the Cisco Catalyst Center system."
+                        "There is no reserve ip pool '{0}' present in the Cisco Catalyst Center."
                         .format(ip_pool_name)
                     )
                     self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()

--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -2732,8 +2732,8 @@ class VirtualNetwork(DnacBase):
                 anchored_fabric_id = vn_details_in_ccc.get("anchoredSiteId")
                 if not anchored_fabric_id:
                     self.msg = (
-                        "Given virtual network '{0}' is not anchored at any fabric site so cannot make "
-                        "any configuration change in the anycast gateway.".format(vn_name)
+                        "There is no reserve ip pool '{0}' present in the Cisco Catalyst Center system."
+                        .format(ip_pool_name)
                     )
                     self.set_operation_result("failed", False, self.msg, "ERROR").check_return_status()
 

--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -2041,7 +2041,8 @@ class VirtualNetwork(DnacBase):
             response = response.get("response")
             self.log("Received API response from 'get_anycast_gateways' for the IP Pool '{0}': {1}".format(ip_pool_name, str(response)), "DEBUG")
             if not response:
-                self.log("There is no gateway '{0}' present in the Cisco Catalyst Center system.", "INFO")
+                unique_anycast = vn_name + "_" + ip_pool_name
+                self.log("Gateway '{0}' is not present in the Cisco Catalyst Center.".format(unique_anycast), "INFO")
                 return None
 
             self.log("Returning Anycast Gateway details for IP Pool '{0}': {1}".format(ip_pool_name, str(response[0])), "INFO")

--- a/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_sda_fabric_virtual_networks_workflow_manager.py
@@ -270,6 +270,7 @@ class TestDnacFabricSitesZonesWorkflow(TestDnacModule):
                 self.test_data.get("get_anycast_gateway_details"),
                 self.test_data.get("get_site_details"),
                 self.test_data.get("get_fabric_site_details"),
+                self.test_data.get("get_reserve_ip_pool_details"),
                 self.test_data.get("get_anycast_gateway_details"),
                 self.test_data.get("get_anycast_vn_response"),
                 self.test_data.get("response_get_task_id_success"),


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue. Also, include relevant motivation and context.

-- Fix the misleading error message when IP pool is not present at given fabric site as well as in anchored site means it's not there in the Catalyst Center.

-- Also fix the issue of issue of workflow shall not exit with failure if the targeted l3 gateway is already removed from fab and reserved pool


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

