### PR TITLE
Bug fix: Failure observed during assignment of device credentials to …

### DIFF
--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2934,9 +2934,9 @@ class DeviceCredential(DnacBase):
                     response, "update_device_credential_settings_for_a_site").check_return_status()
         if final_response:
             self.log("Device credential assigned to site {0} is successfully."
-                    .format(site_ids), "INFO")
+                     .format(site_ids), "INFO")
             self.log("Desired State for assign credentials to a site: {0}"
-                    .format(final_response), "DEBUG")
+                     .format(final_response), "DEBUG")
             result_assign_credential.update({
                 "Assign Credentials": {
                     "response": final_response,

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2789,6 +2789,7 @@ class DeviceCredential(DnacBase):
         })
         self.msg = "Global Credential is assigned Successfully"
         self.status = "success"
+        self.log("Process to assign device credentials to the global site completed successfully.", "INFO")
         return self
 
     def assign_credentials_to_site(self):
@@ -2815,11 +2816,14 @@ class DeviceCredential(DnacBase):
 
         site_ids = self.want.get("site_id")
         if self.compare_dnac_versions(current_version, "2.3.7.6") >= 0:
+
             site_exists, global_site_id = self.get_site_id("Global")
             if global_site_id in site_ids:
+
                 self.log("Global site detected in site IDs. Processing global credential assignment.", "INFO")
                 assign_credentials_to_site = self.config[0]['assign_credentials_to_site'].copy()
                 if "site_name" in assign_credentials_to_site:
+
                     site_names = assign_credentials_to_site.pop("site_name")
                     self.log(
                         "Removed 'site_name' from credential assignment configuration: {0}".format(site_names),

--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -2702,6 +2702,7 @@ class DeviceCredential(DnacBase):
         Returns:
             any: The resolved credential value to use (could be `input_value`, `global_value`, or `{}`).
         """
+
         # Explicitly return the empty dictionary if input_value is {}
         if input_value == {}:
             return {}
@@ -2727,6 +2728,7 @@ class DeviceCredential(DnacBase):
         Returns:
             self: Updated instance with assignment status and messages.
         """
+
         self.log(
             "Starting the process to assign device credentials to the global site. "
             "Global Site ID: {} | Initial Credential Parameters: {}".format(
@@ -2802,6 +2804,7 @@ class DeviceCredential(DnacBase):
             self
         """
 
+        current_version = self.get_ccc_version()
         result_assign_credential = self.result.get("response")[0].get("assign_credential")
         credential_params_template = copy.deepcopy(self.want.get("assign_credentials"))  # Store original template
         final_response = []
@@ -2811,7 +2814,7 @@ class DeviceCredential(DnacBase):
         )
 
         site_ids = self.want.get("site_id")
-        if self.get_ccc_version_as_integer() >= self.get_ccc_version_as_int_from_str("2.3.7.6"):
+        if self.compare_dnac_versions(current_version, "2.3.7.6") >= 0:
             site_exists, global_site_id = self.get_site_id("Global")
             if global_site_id in site_ids:
                 self.log("Global site detected in site IDs. Processing global credential assignment.", "INFO")
@@ -2854,7 +2857,7 @@ class DeviceCredential(DnacBase):
 
         for site_id in site_ids:
             self.log("Processing credential assignment for site ID: {0}".format(site_id), "INFO")
-            if self.get_ccc_version_as_integer() <= self.get_ccc_version_as_int_from_str("2.3.5.3"):
+            if self.compare_dnac_versions(current_version, "2.3.5.3") <= 0:
                 credential_params_template.update({"site_id": site_id})
                 final_response.append(copy.deepcopy(credential_params_template))
                 response = self.dnac._exec(


### PR DESCRIPTION
…Global Site

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
This PR includes Bug fix : 
Failure observed during assignment of device credentials to Global Site

Bug Fix: Failure observed during assignment of device credentials to Global Site in CatC version 2.3.7.10 using Ansible module cisco.dnac:6.32.0.
The device credential assignment fails with the message:
Failed to assign credentials to Global site. Missing or invalid parameters: snmp_v2c_read, snmp_v2c_write

Root Cause (if applicable): The assignment logic was expecting all the parameters for global site.
as mentioned in bug description, its expecting snmp_v2c_read and snmp_v2c_write credentials, even though these credentials were neither configured nor intended to be assigned. The input configuration only specified SNMPv3 and HTTPS credentials for the global site, making this validation unnecessary.

Fix Implemented: Credential validation logic was enhanced to:

Verify presence of required credential types only if they are part of the configuration for assignment.

Respect explicit {} (empty dict) inputs as intentional null assignments and skip missing value checks in those cases.

Apply fallback logic: if any credential is None, it attempts to fetch it from the global credential set (if applicable), otherwise defaults to {}.

This ensures proper handling of partial or specific credential assignments without falsely flagging missing credentials.

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [yes] Manual testing
- [yes] Unit tests
- [yes] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

