### PR TITLE
Bug fixed - application Policy 

### DIFF
--- a/plugins/modules/application_policy_workflow_manager.py
+++ b/plugins/modules/application_policy_workflow_manager.py
@@ -44,7 +44,11 @@ options:
     required: true
     suboptions:
       queuing_profile:
-        description: Defines queuing profile settings for applications.
+        description:
+            - Defines queuing profile settings for applications.
+            - Updating a queuing profile to switch between common bandwidth percentage across different interface speeds
+              and using different bandwidth percentages for each interface speed (i.e., changing is_common_between_all_interface_speeds
+              from true to false or vice versa) is not supported. If such a change is required, a new queuing profile must be created.
         type: list
         elements: dict
         suboptions:
@@ -5473,12 +5477,12 @@ class ApplicationPolicy(DnacBase):
             no_update_list.append(msg)
 
         if self.deleted_application_policy:
-            msg = "Application Policie(s) '{0}' deleted successfully from Cisco Catalyst Center.".format("', '".join(self.deleted_application_policy))
+            msg = "Application Policy(ies) '{0}' deleted successfully from Cisco Catalyst Center.".format("', '".join(self.deleted_application_policy))
             result_msg_list.append(msg)
 
         if self.no_deleted_application_policy:
             msg = (
-                "Application Policie(s) '{0}' do not exist or are already deleted in Cisco Catalyst Center."
+                "Application Policy(ies) '{0}' do not exist or are already deleted in Cisco Catalyst Center."
                 .format("', '".join(self.no_deleted_application_policy))
             )
             no_update_list.append(msg)
@@ -5494,7 +5498,6 @@ class ApplicationPolicy(DnacBase):
 
         if self.no_update_queuing_profile:
             msg = "Queuing Profile(s) '{0}' need no update in Cisco Catalyst Center.".format("', '".join(self.no_update_queuing_profile))
-            self.log(self.no_update_queuing_profile)
             no_update_list.append(msg)
 
         if self.deleted_queuing_profile:

--- a/tests/unit/modules/dnac/fixtures/application_policy_workflow_manager.json
+++ b/tests/unit/modules/dnac/fixtures/application_policy_workflow_manager.json
@@ -1181,8 +1181,6 @@
       "message": "Successfully deleted policies: policy_1"},
 
 
-
-
 "playbook_application_policy_update_wireless": [
   {
     "application_policy": {
@@ -1741,20 +1739,6 @@
   "response": "Application policy queuing profile 'new' updated successfully."},
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   "playbook_create_application_servername":[
     {
         "application": [
@@ -2078,10 +2062,2236 @@
 "get_application_policy_111": {"response": [{"id": "39f5471a-8475-45b0-85ed-88ad63c694f0", "instanceId": 819503236, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362572, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362572, "name": "Policy_3_tunneling", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "d1dffce5-8e32-4b0a-9777-4484cbfee285", "instanceId": 820908360, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "a5b9e30e-07dc-4084-8171-0099d506d158", "instanceId": 821035390, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "e177a8f9-51bd-4510-8c72-38ebd8ae868f", "instanceId": 819472481, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "4f13210d-344e-4077-ad2e-363f1665ce13", "instanceId": 820917303, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "48a84163-09fd-409e-831a-a7f8f5bfede9", "instanceId": 819473451, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "4d71fffb-01fe-4347-baa0-59ff022aec17"}], "displayName": "0"}, "displayName": "0"}, {"id": "4544fc09-376c-47cc-9757-a6957b904d0f", "instanceId": 819503232, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362501, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362501, "name": "Policy_3_file-sharing", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "c0d12c14-2beb-406d-971b-0e8a3dee9c5a", "instanceId": 820908356, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "ffce2a4a-6482-406f-b2f9-dd01a0a0d363", "instanceId": 821035386, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "7b846538-552d-471a-89b7-0174e6ebbbde", "instanceId": 819472477, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "99497443-b9f5-44cb-b324-53463680ed94", "instanceId": 820917299, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_RELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "847f834a-0989-4578-87e2-c552b6027df7", "instanceId": 819473447, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "0339555a-974a-4f54-9c4a-82da248a3673"}], "displayName": "0"}, "displayName": "0"}, {"id": "7d7cfca0-632e-4647-93b5-862bb557fd98", "instanceId": 819503237, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362574, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362574, "name": "Policy_3_general-media", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "4b833ae7-d1c0-4ea0-86d7-60c07d80e591", "instanceId": 820908361, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "fa0c65e6-ee8d-45fd-9b94-929e53115ab7", "instanceId": 821035391, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "b3601a52-2baf-4725-aff2-44f9e2d85873", "instanceId": 819472482, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "ef9ac5b5-674d-4a5e-a477-83ce8712cc39", "instanceId": 820917304, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "f60afa35-816d-4248-a0dc-0f4ec5e3aece", "instanceId": 819473452, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "ca60f9b3-4c1d-4550-925a-db21dfc524c9"}], "displayName": "0"}, "displayName": "0"}, {"id": "93ddca3b-c2b5-4cf6-ac07-951ee4e898bf", "instanceId": 819503235, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362569, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362569, "name": "Policy_3_collaboration-apps", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "a46a1fa3-c6c7-4503-b62f-ae2f95f5c88b", "instanceId": 820908359, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "4198e85b-334d-4079-8c00-02e9dbf922f0", "instanceId": 821035389, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "dae047d2-c64d-4a70-b172-27dfbfa15e05", "instanceId": 819472480, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "8f4e274a-c409-4053-918b-6732081d93a0", "instanceId": 820917302, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "70f56a3f-57f5-4f21-b22f-f31501d14d4a", "instanceId": 819473450, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "7c6ea543-dddc-4e45-b490-1d3a1630f7ef"}], "displayName": "0"}, "displayName": "0"}, {"id": "b3915c7c-1561-4b18-b1a8-c77fc0d406b0", "instanceId": 819503234, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362565, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362565, "name": "Policy_3_backup-and-storage", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "b0c046a7-84cc-4a27-982a-81b2ce74f9d1", "instanceId": 820908358, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "75617834-c147-4f3a-b587-53eb34148196", "instanceId": 821035388, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "cbd024d0-caa1-441a-bdc8-409d07039cc9", "instanceId": 819472479, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "946472ad-d4e3-4d37-b884-4fc94b83a7d6", "instanceId": 820917301, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "90ad9af5-51ff-4f93-8065-077c56c1610d", "instanceId": 819473449, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "6a4bd851-fc77-4ecd-b6aa-c355c74be3a1"}], "displayName": "0"}, "displayName": "0"}, {"id": "d376bcc3-ea7e-4d4a-8401-3979cd1ee21a", "instanceId": 819503233, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362504, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362504, "name": "Policy_3_email", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "47e3e7af-2ae8-4f27-98b8-b5420e2a72f5", "instanceId": 820908357, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "77061739-5afe-4c70-a746-3eba64f5789b", "instanceId": 821035387, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "ed779b4f-ad48-4ca1-b615-20056b96ff05", "instanceId": 819472478, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "clause": [{"id": "3cfaa7d1-3d59-4fca-b88c-9014b75f619c", "instanceId": 820917300, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "a866d694-4716-40d8-b8f6-a2805095698d", "instanceId": 819473448, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "scalableGroup": [{"idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}], "displayName": "0"}, "displayName": "0"}, {"id": "df6e1a27-ff0f-4d8e-8554-354daaf7895b", "instanceId": 819503231, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "createTime": 1743656362497, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1743656362497, "name": "Policy_3_a5", "namespace": "policy:application:Policy_3", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "Policy_3", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "10cae50b-c17b-401a-9847-3329bd56b7f8", "instanceId": 820908355, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "name": "Policy_3", "advancedPolicyScopeElement": [{"id": "31d3981b-5653-402a-92b6-7874e92c5ef3", "instanceId": 821035385, "instanceCreatedOn": 1743656363412, "instanceUpdatedOn": 1743656363412, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": ["ent-ssid-2-wpa2"], "displayName": "0"}], "displayName": "0"}, "contract": {"idRef": "43329924-f1df-4d41-b4f3-1b93911358c3"}, "contractList": [], "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "displayName": "0"}], "version": "1.0"},
 "create_policy_wireless_response":
 {
-  "response": "Application policy 'Policy_3' created successfully."}
+  "response": "Application policy 'Policy_3' created successfully."},
 
 
+"playbook_multiple_profile_delete": [
+  {
+      "queuing_profile": [
+          {
+              "profile_name": "b5"
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_delete": {
+  "response": [
+    {
+      "id": "98a64bcf-fa64-4d2c-a0d8-3ec7145b44ac",
+      "instanceId": 852441299,
+      "instanceCreatedOn": 1746764888070,
+      "instanceUpdatedOn": 1746764888070,
+      "instanceVersion": 0,
+      "createTime": 1746764888063,
+      "deployed": false,
+      "description": "sample desc",
+      "isSeeded": false,
+      "isStale": false,
+      "lastUpdateTime": 1746764888063,
+      "name": "b5",
+      "namespace": "98a64bcf-fa64-4d2c-a0d8-3ec7145b44ac",
+      "provisioningState": "DEFINED",
+      "qualifier": "application",
+      "resourceVersion": 0,
+      "targetIdList": [
+        
+      ],
+      "type": "contract",
+      "cfsChangeInfo": [
+        
+      ],
+      "customProvisions": [
+        
+      ],
+      "externalIntentSourceInfos": [
+        
+      ],
+      "genId": 0,
+      "internal": false,
+      "isDeleted": false,
+      "iseReserved": false,
+      "pushed": false,
+      "clause": [
+        {
+          "id": "63fe0f36-5c80-417f-86a2-0e42863841c3",
+          "instanceId": 852811329,
+          "instanceCreatedOn": 1746764888070,
+          "instanceUpdatedOn": 1746764888070,
+          "instanceVersion": 0,
+          "priority": 1,
+          "isCommonBetweenAllInterfaceSpeeds": false,
+          "interfaceSpeedBandwidthClauses": [
+            {
+              "id": "f0e02eff-7760-4401-ba25-a77ef9eaa00d",
+              "instanceId": 852812405,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "HUNDRED_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "909efaa1-3806-4b97-8d8d-4065d53e8073",
+                  "instanceId": 877016486,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e3997e0c-d06e-4bb5-b94b-6c7fd60e1d76",
+                  "instanceId": 877016484,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9cc0d313-bee6-498b-9d93-fabb20d07ea2",
+                  "instanceId": 877016485,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "49eb897f-2601-4c34-aa3d-b19f60ce81f2",
+                  "instanceId": 877016482,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "31f13948-9b1b-4b9c-a839-9aad1895f250",
+                  "instanceId": 877016483,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "1b87926d-6c49-45e7-9b11-2ceaa52bde25",
+                  "instanceId": 877016480,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "6d1c47c9-9af7-4a5f-bd20-ccbcc41ff2b8",
+                  "instanceId": 877016481,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e96d65f7-6d36-43ad-add3-6e83f69ab4bd",
+                  "instanceId": 877016478,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "2c9b0725-5069-4156-a6f4-7b63a27ec5e0",
+                  "instanceId": 877016479,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "3ad8af58-f3e6-4d95-9b8e-773978e90265",
+                  "instanceId": 877016476,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9693132b-48a5-4001-b922-fb887007cfa0",
+                  "instanceId": 877016477,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cab62c9d-4f65-4ec0-8cb6-e67737fd1783",
+                  "instanceId": 877016475,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "2187a4a7-7943-41bb-8fb7-aebcc095d035",
+              "instanceId": 852812406,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "ONE_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "f62a0872-f0db-4e6d-bfa2-f1e5d6d628f1",
+                  "instanceId": 877016487,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cff5cc67-571a-4d7e-9856-61b9d1145dab",
+                  "instanceId": 877016498,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "46d49cda-34e0-4ecd-9649-0d7aefc0efcc",
+                  "instanceId": 877016496,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9db57a20-a1e9-4b62-8c11-4c91393901e9",
+                  "instanceId": 877016497,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9cf2e44a-fd23-4d50-acf6-8e95dc9dfa2c",
+                  "instanceId": 877016494,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "84496f7b-e455-413c-a551-f3ea4dc5e693",
+                  "instanceId": 877016495,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4d05fe68-0e65-4311-b019-2c7ee3f3c4e4",
+                  "instanceId": 877016492,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ced80c47-af84-4b15-8653-054e79395a7c",
+                  "instanceId": 877016493,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "74250d43-2283-48d7-82e3-8a1a2a6aea33",
+                  "instanceId": 877016490,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "60a8555f-1f90-41c5-a519-427d22c8e270",
+                  "instanceId": 877016491,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8ca09f4f-93a1-4429-b45b-b143fc4d6681",
+                  "instanceId": 877016488,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "40182cea-026d-427a-ad97-312189d746ff",
+                  "instanceId": 877016489,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "2a809891-3fbc-45c8-ad3b-e3112f04d287",
+              "instanceId": 852812407,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "TEN_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "d44e3337-286f-4544-b930-1cc152c962a9",
+                  "instanceId": 877016502,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "07f68a54-a00b-43d3-a2f2-90dced9b799d",
+                  "instanceId": 877016503,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "69d7e4c5-d63d-4357-b065-d5e1d5f90fc9",
+                  "instanceId": 877016500,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "27fde6c8-b8a2-4058-961d-242c82ce8f50",
+                  "instanceId": 877016501,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "5ca3efaa-5484-4080-888c-29e496c287cb",
+                  "instanceId": 877016499,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "acd543cc-38d8-4732-922a-8fcf34657175",
+                  "instanceId": 877016510,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "196f2c34-7dd3-4dbd-a819-e9bbb4e99749",
+                  "instanceId": 877016508,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e8c4a211-8980-43f0-91fd-42f811142356",
+                  "instanceId": 877016509,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "243a0376-516a-4b37-b644-02058750948a",
+                  "instanceId": 877016506,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "87d27f2a-d0fa-4df2-9518-2961c9380c12",
+                  "instanceId": 877016507,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4f45896c-d9bc-457e-beb0-208faac49cb1",
+                  "instanceId": 877016504,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a7c51f4f-ebd3-4c76-bcf7-7bcd1105bd62",
+                  "instanceId": 877016505,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "93736899-3d2b-4b15-b379-7f25653ca1a1",
+              "instanceId": 852812408,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "ONE_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "338f956e-c67c-46b9-90a4-f4bcb57b5a03",
+                  "instanceId": 877016518,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ef0341b9-e083-4a3c-bccc-989a29ed1065",
+                  "instanceId": 877016519,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8360d7b4-cc17-4dad-8aa2-ff150eed1547",
+                  "instanceId": 877016516,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "7a72a346-da9c-41a4-93a9-34b451cea881",
+                  "instanceId": 877016517,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "85a74b75-1367-4a27-a13f-25f9703d1b62",
+                  "instanceId": 877016514,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "214394e7-4be5-47af-af70-a0e438f464e6",
+                  "instanceId": 877016515,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ff650268-53e4-4f17-af10-3b14579ac8ea",
+                  "instanceId": 877016512,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8c406c27-4472-46e3-a16f-cd2e84f7f045",
+                  "instanceId": 877016513,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "be72fff8-1f23-425b-851f-d8c78d1851a6",
+                  "instanceId": 877016511,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8ec0c859-e9ae-459b-8eb6-73a5e0fede77",
+                  "instanceId": 877016522,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "eb994e1a-bc79-42bf-9228-f14001c82cc9",
+                  "instanceId": 877016520,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "f124bbf7-e8b1-44f8-96f3-cefd1394fbf8",
+                  "instanceId": 877016521,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "522e74c8-651b-4f84-a65b-10949c7e5630",
+              "instanceId": 852812409,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "HUNDRED_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "17b2029c-5d1d-4f1e-985d-97d703f1cacc",
+                  "instanceId": 877016534,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "5f491859-355d-4c67-b90c-cc143066ec3e",
+                  "instanceId": 877016532,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ae340ba8-8c53-4d7a-9f09-3985ae559c66",
+                  "instanceId": 877016533,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "d692b665-1023-4dca-9be3-2875cff0e786",
+                  "instanceId": 877016530,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "07111d5e-32f4-4dda-8e6e-d56e21e2568d",
+                  "instanceId": 877016531,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "11c7d61d-3691-4e9b-96f9-cc3a989accc1",
+                  "instanceId": 877016528,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "fad003b9-4bc4-40fc-8ff7-66097e9e01a1",
+                  "instanceId": 877016529,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4a634a0b-fc27-4a1f-b782-682784be1b62",
+                  "instanceId": 877016526,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "737cfe2f-2f8d-4d99-82de-b493e3e6950d",
+                  "instanceId": 877016527,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "0fc531c0-348b-4390-8b01-971a0bf822a6",
+                  "instanceId": 877016524,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 25,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "67226430-bfd6-425b-845c-813930988542",
+                  "instanceId": 877016525,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "bc6f2c22-6063-4c52-83c1-69300daa2081",
+                  "instanceId": 877016523,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "91136451-a032-47eb-ad13-8ade4918d231",
+              "instanceId": 852812410,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "TEN_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "02df54f6-b3f8-4cad-b601-9606f1f3a342",
+                  "instanceId": 877016535,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cb89cb01-f9c5-4769-b45c-b271d5301f05",
+                  "instanceId": 877016546,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "3fccaf67-38cd-4675-9db1-92ed2bd98d3c",
+                  "instanceId": 877016544,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "62532c19-9798-4faf-9ca7-16a799f5121f",
+                  "instanceId": 877016545,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "f8c1392a-394f-4bbc-875f-9e6c1963d713",
+                  "instanceId": 877016542,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 25,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "47da3379-25cb-4250-a916-deb688a3f9a0",
+                  "instanceId": 877016543,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a78b3106-e1de-45c6-a53e-e27d81144cdb",
+                  "instanceId": 877016540,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 4,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4fa19c54-fdc6-4e30-abea-68aaafdb41d5",
+                  "instanceId": 877016541,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "dc8026a2-19f3-416e-92f4-9c0306185d05",
+                  "instanceId": 877016538,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "c4fe3a31-4d9a-4419-b0d3-7cf39b55670f",
+                  "instanceId": 877016539,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a79af1f3-d629-4484-98e7-d41ca6330b12",
+                  "instanceId": 877016536,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 6,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "7e1dbec9-9b11-49de-8821-4793c6184898",
+                  "instanceId": 877016537,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            }
+          ],
+          "displayName": "0"
+        }
+      ],
+      "contractClassifier": [
+        
+      ],
+      "displayName": "0"
+    }
+  ],
+  "version": "1.0"
+},
+"get_application_policy_queuing_profile_delete2": {
+  "response": [
+    {
+      "id": "98a64bcf-fa64-4d2c-a0d8-3ec7145b44ac",
+      "instanceId": 852441299,
+      "instanceCreatedOn": 1746764888070,
+      "instanceUpdatedOn": 1746764888070,
+      "instanceVersion": 0,
+      "createTime": 1746764888063,
+      "deployed": false,
+      "description": "sample desc",
+      "isSeeded": false,
+      "isStale": false,
+      "lastUpdateTime": 1746764888063,
+      "name": "b5",
+      "namespace": "98a64bcf-fa64-4d2c-a0d8-3ec7145b44ac",
+      "provisioningState": "DEFINED",
+      "qualifier": "application",
+      "resourceVersion": 0,
+      "targetIdList": [
+        
+      ],
+      "type": "contract",
+      "cfsChangeInfo": [
+        
+      ],
+      "customProvisions": [
+        
+      ],
+      "externalIntentSourceInfos": [
+        
+      ],
+      "genId": 0,
+      "internal": false,
+      "isDeleted": false,
+      "iseReserved": false,
+      "pushed": false,
+      "clause": [
+        {
+          "id": "63fe0f36-5c80-417f-86a2-0e42863841c3",
+          "instanceId": 852811329,
+          "instanceCreatedOn": 1746764888070,
+          "instanceUpdatedOn": 1746764888070,
+          "instanceVersion": 0,
+          "priority": 1,
+          "isCommonBetweenAllInterfaceSpeeds": false,
+          "interfaceSpeedBandwidthClauses": [
+            {
+              "id": "f0e02eff-7760-4401-ba25-a77ef9eaa00d",
+              "instanceId": 852812405,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "HUNDRED_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "909efaa1-3806-4b97-8d8d-4065d53e8073",
+                  "instanceId": 877016486,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e3997e0c-d06e-4bb5-b94b-6c7fd60e1d76",
+                  "instanceId": 877016484,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9cc0d313-bee6-498b-9d93-fabb20d07ea2",
+                  "instanceId": 877016485,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "49eb897f-2601-4c34-aa3d-b19f60ce81f2",
+                  "instanceId": 877016482,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "31f13948-9b1b-4b9c-a839-9aad1895f250",
+                  "instanceId": 877016483,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "1b87926d-6c49-45e7-9b11-2ceaa52bde25",
+                  "instanceId": 877016480,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "6d1c47c9-9af7-4a5f-bd20-ccbcc41ff2b8",
+                  "instanceId": 877016481,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e96d65f7-6d36-43ad-add3-6e83f69ab4bd",
+                  "instanceId": 877016478,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "2c9b0725-5069-4156-a6f4-7b63a27ec5e0",
+                  "instanceId": 877016479,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "3ad8af58-f3e6-4d95-9b8e-773978e90265",
+                  "instanceId": 877016476,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9693132b-48a5-4001-b922-fb887007cfa0",
+                  "instanceId": 877016477,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cab62c9d-4f65-4ec0-8cb6-e67737fd1783",
+                  "instanceId": 877016475,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "2187a4a7-7943-41bb-8fb7-aebcc095d035",
+              "instanceId": 852812406,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "ONE_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "f62a0872-f0db-4e6d-bfa2-f1e5d6d628f1",
+                  "instanceId": 877016487,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cff5cc67-571a-4d7e-9856-61b9d1145dab",
+                  "instanceId": 877016498,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "46d49cda-34e0-4ecd-9649-0d7aefc0efcc",
+                  "instanceId": 877016496,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9db57a20-a1e9-4b62-8c11-4c91393901e9",
+                  "instanceId": 877016497,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "9cf2e44a-fd23-4d50-acf6-8e95dc9dfa2c",
+                  "instanceId": 877016494,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "84496f7b-e455-413c-a551-f3ea4dc5e693",
+                  "instanceId": 877016495,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4d05fe68-0e65-4311-b019-2c7ee3f3c4e4",
+                  "instanceId": 877016492,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ced80c47-af84-4b15-8653-054e79395a7c",
+                  "instanceId": 877016493,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "74250d43-2283-48d7-82e3-8a1a2a6aea33",
+                  "instanceId": 877016490,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "60a8555f-1f90-41c5-a519-427d22c8e270",
+                  "instanceId": 877016491,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8ca09f4f-93a1-4429-b45b-b143fc4d6681",
+                  "instanceId": 877016488,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "40182cea-026d-427a-ad97-312189d746ff",
+                  "instanceId": 877016489,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "2a809891-3fbc-45c8-ad3b-e3112f04d287",
+              "instanceId": 852812407,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "TEN_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "d44e3337-286f-4544-b930-1cc152c962a9",
+                  "instanceId": 877016502,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "07f68a54-a00b-43d3-a2f2-90dced9b799d",
+                  "instanceId": 877016503,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "69d7e4c5-d63d-4357-b065-d5e1d5f90fc9",
+                  "instanceId": 877016500,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "27fde6c8-b8a2-4058-961d-242c82ce8f50",
+                  "instanceId": 877016501,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "5ca3efaa-5484-4080-888c-29e496c287cb",
+                  "instanceId": 877016499,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "acd543cc-38d8-4732-922a-8fcf34657175",
+                  "instanceId": 877016510,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "196f2c34-7dd3-4dbd-a819-e9bbb4e99749",
+                  "instanceId": 877016508,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "e8c4a211-8980-43f0-91fd-42f811142356",
+                  "instanceId": 877016509,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "243a0376-516a-4b37-b644-02058750948a",
+                  "instanceId": 877016506,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "87d27f2a-d0fa-4df2-9518-2961c9380c12",
+                  "instanceId": 877016507,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4f45896c-d9bc-457e-beb0-208faac49cb1",
+                  "instanceId": 877016504,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a7c51f4f-ebd3-4c76-bcf7-7bcd1105bd62",
+                  "instanceId": 877016505,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "93736899-3d2b-4b15-b379-7f25653ca1a1",
+              "instanceId": 852812408,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "ONE_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "338f956e-c67c-46b9-90a4-f4bcb57b5a03",
+                  "instanceId": 877016518,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ef0341b9-e083-4a3c-bccc-989a29ed1065",
+                  "instanceId": 877016519,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8360d7b4-cc17-4dad-8aa2-ff150eed1547",
+                  "instanceId": 877016516,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "7a72a346-da9c-41a4-93a9-34b451cea881",
+                  "instanceId": 877016517,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "85a74b75-1367-4a27-a13f-25f9703d1b62",
+                  "instanceId": 877016514,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "214394e7-4be5-47af-af70-a0e438f464e6",
+                  "instanceId": 877016515,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ff650268-53e4-4f17-af10-3b14579ac8ea",
+                  "instanceId": 877016512,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8c406c27-4472-46e3-a16f-cd2e84f7f045",
+                  "instanceId": 877016513,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "be72fff8-1f23-425b-851f-d8c78d1851a6",
+                  "instanceId": 877016511,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "8ec0c859-e9ae-459b-8eb6-73a5e0fede77",
+                  "instanceId": 877016522,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "eb994e1a-bc79-42bf-9228-f14001c82cc9",
+                  "instanceId": 877016520,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "f124bbf7-e8b1-44f8-96f3-cefd1394fbf8",
+                  "instanceId": 877016521,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "522e74c8-651b-4f84-a65b-10949c7e5630",
+              "instanceId": 852812409,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "HUNDRED_MBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "17b2029c-5d1d-4f1e-985d-97d703f1cacc",
+                  "instanceId": 877016534,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "5f491859-355d-4c67-b90c-cc143066ec3e",
+                  "instanceId": 877016532,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "ae340ba8-8c53-4d7a-9f09-3985ae559c66",
+                  "instanceId": 877016533,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "d692b665-1023-4dca-9be3-2875cff0e786",
+                  "instanceId": 877016530,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "07111d5e-32f4-4dda-8e6e-d56e21e2568d",
+                  "instanceId": 877016531,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "11c7d61d-3691-4e9b-96f9-cc3a989accc1",
+                  "instanceId": 877016528,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 10,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "fad003b9-4bc4-40fc-8ff7-66097e9e01a1",
+                  "instanceId": 877016529,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4a634a0b-fc27-4a1f-b782-682784be1b62",
+                  "instanceId": 877016526,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "737cfe2f-2f8d-4d99-82de-b493e3e6950d",
+                  "instanceId": 877016527,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "0fc531c0-348b-4390-8b01-971a0bf822a6",
+                  "instanceId": 877016524,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 25,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                },
+                {
+                  "id": "67226430-bfd6-425b-845c-813930988542",
+                  "instanceId": 877016525,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "bc6f2c22-6063-4c52-83c1-69300daa2081",
+                  "instanceId": 877016523,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            },
+            {
+              "id": "91136451-a032-47eb-ad13-8ade4918d231",
+              "instanceId": 852812410,
+              "instanceCreatedOn": 1746764888070,
+              "instanceUpdatedOn": 1746764888070,
+              "instanceVersion": 0,
+              "interfaceSpeed": "TEN_GBPS",
+              "tcBandwidthSettings": [
+                {
+                  "id": "02df54f6-b3f8-4cad-b601-9606f1f3a342",
+                  "instanceId": 877016535,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 3,
+                  "trafficClass": "NETWORK_CONTROL",
+                  "displayName": "0"
+                },
+                {
+                  "id": "cb89cb01-f9c5-4769-b45c-b271d5301f05",
+                  "instanceId": 877016546,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 15,
+                  "trafficClass": "BULK_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "3fccaf67-38cd-4675-9db1-92ed2bd98d3c",
+                  "instanceId": 877016544,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "BEST_EFFORT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "62532c19-9798-4faf-9ca7-16a799f5121f",
+                  "instanceId": 877016545,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 2,
+                  "trafficClass": "BROADCAST_VIDEO",
+                  "displayName": "0"
+                },
+                {
+                  "id": "f8c1392a-394f-4bbc-875f-9e6c1963d713",
+                  "instanceId": 877016542,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 25,
+                  "trafficClass": "VOIP_TELEPHONY",
+                  "displayName": "0"
+                },
+                {
+                  "id": "47da3379-25cb-4250-a916-deb688a3f9a0",
+                  "instanceId": 877016543,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_STREAMING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a78b3106-e1de-45c6-a53e-e27d81144cdb",
+                  "instanceId": 877016540,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 4,
+                  "trafficClass": "OPS_ADMIN_MGMT",
+                  "displayName": "0"
+                },
+                {
+                  "id": "4fa19c54-fdc6-4e30-abea-68aaafdb41d5",
+                  "instanceId": 877016541,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "SCAVENGER",
+                  "displayName": "0"
+                },
+                {
+                  "id": "dc8026a2-19f3-416e-92f4-9c0306185d05",
+                  "instanceId": 877016538,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "MULTIMEDIA_CONFERENCING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "c4fe3a31-4d9a-4419-b0d3-7cf39b55670f",
+                  "instanceId": 877016539,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 5,
+                  "trafficClass": "TRANSACTIONAL_DATA",
+                  "displayName": "0"
+                },
+                {
+                  "id": "a79af1f3-d629-4484-98e7-d41ca6330b12",
+                  "instanceId": 877016536,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 6,
+                  "trafficClass": "SIGNALING",
+                  "displayName": "0"
+                },
+                {
+                  "id": "7e1dbec9-9b11-49de-8821-4793c6184898",
+                  "instanceId": 877016537,
+                  "instanceCreatedOn": 1746764888070,
+                  "instanceUpdatedOn": 1746764888070,
+                  "instanceVersion": 0,
+                  "bandwidthPercentage": 20,
+                  "trafficClass": "REAL_TIME_INTERACTIVE",
+                  "displayName": "0"
+                }
+              ],
+              "displayName": "0"
+            }
+          ],
+          "displayName": "0"
+        }
+      ],
+      "contractClassifier": [
+        
+      ],
+      "displayName": "0"
+    }
+  ],
+  "version": "1.0"
+},
+"delete_application_policy_queuing_profile_1": {"response": {"taskId": "0196b34d-c9bc-7898-ab86-79a5830671d4", "url": "/api/v1/task/0196b34d-c9bc-7898-ab86-79a5830671d4"}, "version": "1.0"},
+"Task_Details_delete": {"response": {"lastUpdate": 1746764941884, "status": "PENDING", "startTime": 1746764941756, "resultLocation": "/dna/intent/api/v1/tasks/0196b34d-c9bc-7898-ab86-79a5830671d4/detail", "id": "0196b34d-c9bc-7898-ab86-79a5830671d4"}, "version": "1.0"},
+"Task_Details_delete1": {"response": {"endTime": 1746764943491, "lastUpdate": 1746764942271, "status": "SUCCESS", "startTime": 1746764941756, "resultLocation": "/dna/intent/api/v1/tasks/0196b34d-c9bc-7898-ab86-79a5830671d4/detail", "id": "0196b34d-c9bc-7898-ab86-79a5830671d4"}, "version": "1.0"},
+"get_application_policy_queuing_profile_delete4": {"response": [], "version": "1.0"},
+"delete_profile_response": {
+  "response": "Queuing Profile(s) 'b5' deleted successfully from Cisco Catalyst Center."},
 
 
+"playbook_application_delete": [
+  {
+      "application": [
+          {
+              "name": "application1"
+          }
+      ]
+  }
+],
+"get_applications_v2_delete": {"response": [{"id": "b7c0037c-c64a-4981-83ef-d1d660c0d562", "instanceId": 852441300, "instanceVersion": 0, "identitySource": {"id": "7bddb0c5-5e17-454a-a419-ef2af08ac8e9", "type": "APIC-EM"}, "indicativeNetworkIdentity": [], "name": "application1", "namespace": "scalablegroup:application", "networkApplications": [{"id": "86e16660-8dea-47db-9180-42376bf6728f", "applicationSubType": "NONE", "applicationType": "CUSTOM", "categoryId": "42fa6f6d-200d-4be3-81fa-29046c2f67ba", "dscp": "5", "engineId": "4", "longDescription": "sample", "name": "application1", "popularity": 0, "rank": 23, "selectorId": "27002", "trafficClass": "BROADCAST_VIDEO", "displayName": "853056316"}], "networkIdentity": [{"id": "800ef4ff-7fbd-486e-bb97-2b03a17f0094", "ipv4Subnet": ["7.7.7.7"], "ipv6Subnet": [], "lowerPort": 10, "ports": "110", "protocol": "UDP", "upperPort": 100, "displayName": "853057245"}], "parentScalableGroup": {"id": "c17a3b01-ce32-4f6f-8372-4b6f855ae4b5", "idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}, "qualifier": "application", "scalableGroupExternalHandle": "application1", "scalableGroupType": "APPLICATION", "type": "scalablegroup", "displayName": "852441300"}], "version": "1.0"},
+"get_applications_v2_delete1": {"response": [{"id": "b7c0037c-c64a-4981-83ef-d1d660c0d562", "instanceId": 852441300, "instanceVersion": 0, "identitySource": {"id": "b673a39b-98bf-4b1f-9035-13757a18aa45", "type": "APIC-EM"}, "indicativeNetworkIdentity": [], "name": "application1", "namespace": "scalablegroup:application", "networkApplications": [{"id": "86e16660-8dea-47db-9180-42376bf6728f", "applicationSubType": "NONE", "applicationType": "CUSTOM", "categoryId": "42fa6f6d-200d-4be3-81fa-29046c2f67ba", "dscp": "5", "engineId": "4", "longDescription": "sample", "name": "application1", "popularity": 0, "rank": 23, "selectorId": "27002", "trafficClass": "BROADCAST_VIDEO", "displayName": "853056316"}], "networkIdentity": [{"id": "800ef4ff-7fbd-486e-bb97-2b03a17f0094", "ipv4Subnet": ["7.7.7.7"], "ipv6Subnet": [], "lowerPort": 10, "ports": "110", "protocol": "UDP", "upperPort": 100, "displayName": "853057245"}], "parentScalableGroup": {"id": "ba383269-3d96-48b6-ac48-acd00a113a11", "idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}, "qualifier": "application", "scalableGroupExternalHandle": "application1", "scalableGroupType": "APPLICATION", "type": "scalablegroup", "displayName": "852441300"}], "version": "1.0"},
+"delete_application_v2": {"response": {"taskId": "0196b35e-77ea-7d7d-bd7e-50a3c12b2b79", "url": "/api/v1/task/0196b35e-77ea-7d7d-bd7e-50a3c12b2b79"}, "version": "1.0"},
+"TaskDetails": {"response": {"lastUpdate": 1746766035064, "status": "PENDING", "startTime": 1746766034922, "resultLocation": "/dna/intent/api/v1/tasks/0196b35e-77ea-7d7d-bd7e-50a3c12b2b79/detail", "id": "0196b35e-77ea-7d7d-bd7e-50a3c12b2b79"}, "version": "1.0"},
+"TaskDetails1": {"response": {"endTime": 1746766046442, "lastUpdate": 1746766040353, "status": "SUCCESS", "startTime": 1746766034922, "resultLocation": "/dna/intent/api/v1/tasks/0196b35e-77ea-7d7d-bd7e-50a3c12b2b79/detail", "id": "0196b35e-77ea-7d7d-bd7e-50a3c12b2b79"}, "version": "1.0"},
+"get_applications_v2_": {"response": [], "version": "1.0"},
+"response": {
+  "response": "Application(s) 'application1' deleted successfully from Cisco Catalyst Center."},
 
+
+"playbook_error_1": [
+  {
+      "queuing_profile": {
+          "bandwidth_settings": {
+              "bandwidth_percentages": {
+                  "best_effort": "10",
+                  "broadcast_video": "2",
+                  "bulk_data": "5",
+                  "multimedia_conferencing": "10",
+                  "multimedia_streaming": "10",
+                  "network_control": "3",
+                  "ops_admin_mgmt": "5",
+                  "real_time_interactive": "20",
+                  "scavenger": "5",
+                  "signaling": "10",
+                  "transactional_data": "5",
+                  "voip_telephony": "15"
+              },
+              "interface_speed": "ALL",
+              "is_common_between_all_interface_speeds": true
+          },
+          "profile_description": "sample description",
+          "profile_name": "c1"
+      }
+  }
+],
+"response1": {
+  "response": "'queuing_profile' should be a list, found: <class 'dict'>"},
+
+"playbook_error_2": [
+  {
+      "bandwidth_settings": {
+          "bandwidth_percentages": {
+              "best_effort": "10",
+              "broadcast_video": "2",
+              "bulk_data": "5",
+              "multimedia_conferencing": "10",
+              "multimedia_streaming": "10",
+              "network_control": "3",
+              "ops_admin_mgmt": "5",
+              "real_time_interactive": "20",
+              "scavenger": "5",
+              "signaling": "10",
+              "transactional_data": "5",
+              "voip_telephony": "15"
+          },
+          "interface_speed": "ALL",
+          "is_common_between_all_interface_speeds": true
+      },
+      "profile_description": "sample description",
+      "profile_name": "c1"
+  }
+],
+"response2": {
+  "response": "At least one of the following parameters must be specified in the playbook: queuing_profile, application, application_policy."},
+
+"playbook_error_3": [
+  {
+      "application_policy": {
+          "application_queuing_profile_name": "a5",
+          "clause": [
+              {
+                  "clause_type": "BUSINESS_RELEVANCE",
+                  "relevance_details": [
+                      {
+                          "application_set_name": [
+                              "collaboration-apps"
+                          ],
+                          "relevance": "BUSINESS_RELEVANT"
+                      },
+                      {
+                          "application_set_name": [
+                              "email",
+                              "tunneling"
+                          ],
+                          "relevance": "BUSINESS_IRRELEVANT"
+                      },
+                      {
+                          "application_set_name": [
+                              "backup-and-storage",
+                              "general-media",
+                              "file-sharing"
+                          ],
+                          "relevance": "DEFAULT"
+                      }
+                  ]
+              }
+          ],
+          "device_type": "wired",
+          "name": "policy_1",
+          "policy_status": "deployed",
+          "site_names": [
+              "Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1"
+          ]
+      }
+  }
+],
+"response3": {
+  "response": "'application_policy' should be a list, found: <class 'dict'>"},
+
+"playbook_application_noupdate": [
+  {
+      "application": [
+          {
+              "application_set_name": "email",
+              "description": "sample",
+              "dscp": 5,
+              "engine_id": 4,
+              "helpstring": "sample",
+              "ignore_conflict": true,
+              "name": "application1",
+              "network_identity_setting": {
+                  "ip_subnet": [
+                      "7.7.7.7"
+                  ],
+                  "lower_port": 10,
+                  "port": "110",
+                  "protocol": "UDP",
+                  "upper_port": 100
+              },
+              "rank": 23,
+              "traffic_class": "BROADCAST_VIDEO",
+              "type": "server_ip"
+          }
+      ]
+  }
+],
+"get_applications_v2_noupdate": {"response": [{"id": "f8547329-c65f-4eef-996d-5ea9a5778c7d", "instanceId": 852441304, "instanceVersion": 0, "identitySource": {"id": "236690ab-a1d2-4b37-9a2b-00dc7c1b23fc", "type": "APIC-EM"}, "indicativeNetworkIdentity": [], "name": "application1", "namespace": "scalablegroup:application", "networkApplications": [{"id": "bd8e632c-95d3-410b-b6c4-4b735d855afd", "applicationSubType": "NONE", "applicationType": "CUSTOM", "categoryId": "42fa6f6d-200d-4be3-81fa-29046c2f67ba", "dscp": "5", "engineId": "4", "longDescription": "sample", "name": "application1", "popularity": 0, "rank": 23, "selectorId": "10065", "trafficClass": "BROADCAST_VIDEO", "displayName": "853056317"}], "networkIdentity": [{"id": "6bc42529-b1ef-4c2b-ba3d-1e308738fe7f", "ipv4Subnet": ["7.7.7.7"], "ipv6Subnet": [], "lowerPort": 10, "ports": "110", "protocol": "UDP", "upperPort": 100, "displayName": "853057246"}], "parentScalableGroup": {"id": "c3529382-e41a-493e-87d9-1c7aea05cd47", "idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}, "qualifier": "application", "scalableGroupExternalHandle": "application1", "scalableGroupType": "APPLICATION", "type": "scalablegroup", "displayName": "852441304"}], "version": "1.0"},
+"get_application_sets_noupdate": {"response": [{"id": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a", "identitySource": {"id": "bb67d96f-94d8-4ea5-ac15-622151b1b958", "type": "NBAR"}, "name": "email"}]},
+"get_applications_v2_noupdate1": {"response": [{"id": "f8547329-c65f-4eef-996d-5ea9a5778c7d", "instanceId": 852441304, "instanceVersion": 0, "identitySource": {"id": "536e28a7-f0b7-4491-a0b8-753c76c93d73", "type": "APIC-EM"}, "indicativeNetworkIdentity": [], "name": "application1", "namespace": "scalablegroup:application", "networkApplications": [{"id": "bd8e632c-95d3-410b-b6c4-4b735d855afd", "applicationSubType": "NONE", "applicationType": "CUSTOM", "categoryId": "42fa6f6d-200d-4be3-81fa-29046c2f67ba", "dscp": "5", "engineId": "4", "longDescription": "sample", "name": "application1", "popularity": 0, "rank": 23, "selectorId": "10065", "trafficClass": "BROADCAST_VIDEO", "displayName": "853056317"}], "networkIdentity": [{"id": "6bc42529-b1ef-4c2b-ba3d-1e308738fe7f", "ipv4Subnet": ["7.7.7.7"], "ipv6Subnet": [], "lowerPort": 10, "ports": "110", "protocol": "UDP", "upperPort": 100, "displayName": "853057246"}], "parentScalableGroup": {"id": "69ece305-752a-448e-9517-9dc6cd320a63", "idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}, "qualifier": "application", "scalableGroupExternalHandle": "application1", "scalableGroupType": "APPLICATION", "type": "scalablegroup", "displayName": "852441304"}], "version": "1.0"},
+"get_application_sets_noupdate1": {"response": [{"id": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a", "identitySource": {"id": "bb67d96f-94d8-4ea5-ac15-622151b1b958", "type": "NBAR"}, "name": "email"}]},
+"response4": {
+  "response": "Application(s) 'application1' need no update in Cisco Catalyst Center."},
+
+
+"playbook_policy_noupdate": [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a5",
+              "clause": [
+                  {
+                      "clause_type": "BUSINESS_RELEVANCE",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "email",
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "backup-and-storage",
+                                  "general-media",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wired",
+              "name": "policy_1",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_noupdate": {"response": [{"id": "43329924-f1df-4d41-b4f3-1b93911358c3", "instanceId": 768840254, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "createTime": 1741859335041, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1741859335041, "name": "a5", "namespace": "43329924-f1df-4d41-b4f3-1b93911358c3", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "e3526adb-74b0-4d15-9952-41a78b1f608b", "instanceId": 768903189, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "c8ba1180-26c5-48c4-aa36-9f5ec7d815d1", "instanceId": 768907348, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "e1c79240-6d7e-4b6d-9de2-55ba4df85aae", "instanceId": 768907349, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "872ff518-c685-4143-b1a8-f5b11f0336f2", "instanceId": 768907350, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "2ae407d0-482b-4948-b30b-9e2fc586edf5", "instanceId": 768907351, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "b2999333-c7f3-47f3-be96-6e8cf37e1376", "instanceId": 768907344, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "91334031-ef9e-4720-bb9e-f3fecbaa34aa", "instanceId": 768907345, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "f90d9863-6d97-4cfb-8ccd-27a60cca1f08", "instanceId": 768907346, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "89edce6c-c1b7-43d0-a1a8-eb15c4c0b6dc", "instanceId": 768907347, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "498cfe22-eb03-49de-875f-0b29050b28b1", "instanceId": 768907343, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "b6112849-eb7d-47e6-b9ab-f547744521f0", "instanceId": 768907352, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "f3c49c93-6b8c-47ae-8ce8-36417cc29c47", "instanceId": 768907353, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "008796aa-5948-4c7e-83b1-b38a62158aae", "instanceId": 768907354, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}], "displayName": "0"}, {"id": "af1605d8-edac-43c6-b20d-7ef99f4afb57", "instanceId": 768903190, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "c787ef12-0588-41ba-a247-8b44fbe23256", "instanceId": 768904252, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "b653da4b-744e-48ae-9180-4567a12d97f4", "instanceId": 775056674, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "772b5664-0e67-49c7-8f0d-4da805e4c218", "instanceId": 775056675, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "d35b65f1-401d-433e-b9a9-762adfaf3f2d", "instanceId": 775056673, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "ea455975-487d-4a5f-8f94-a6f463e7c78e", "instanceId": 775056678, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "00ae1d57-15a4-46fa-9d64-09afbb255a5d", "instanceId": 775056679, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "e78f6283-d5e6-475d-8d91-fb0088cc8d1f", "instanceId": 775056676, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "73c5f10b-e609-48c4-b34f-3c5f5c80309f", "instanceId": 775056677, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "d34a91a9-fdbb-4a6b-b804-e94ca2a4ce89", "instanceId": 775056682, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "284a9e01-4b67-435a-9dc8-3f2758979e87", "instanceId": 775056683, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f6ab4791-ef6b-49b5-b85b-9a1b4e203a12", "instanceId": 775056680, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "9f75f59e-add7-4984-ae38-697e87f8df3e", "instanceId": 775056681, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "ad480a0e-a9fc-40a4-9be0-60123041b56b", "instanceId": 775056684, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_noupdate": {"response": [{"id": "6006d257-89f2-44f3-9739-861e13a99763", "instanceId": 852441306, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775377, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775377, "name": "policy_1_a5", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "aff022fb-3b2f-49cd-8ef0-105883845beb", "instanceId": 862912331, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "bc7a222e-c8d9-4735-8cf7-13a29160bd30", "instanceId": 862913518, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contract": {"idRef": "43329924-f1df-4d41-b4f3-1b93911358c3"}, "contractList": [], "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "displayName": "0"}, {"id": "6cb5141f-080f-4419-9b0f-55b098f84360", "instanceId": 852441312, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775388, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775388, "name": "policy_1_file-sharing", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "46f0ca86-570f-4be9-a20f-8b3c98d3a8a4", "instanceId": 862912337, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "7cf8770e-e6cb-4b69-b51c-9bbd742114ee", "instanceId": 862913524, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "0267d287-48b9-48f8-a0e0-407f22ee1810", "instanceId": 862914255, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "9de236df-ae61-4836-9a75-6303da22bd94", "instanceId": 852811335, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "4aefc84a-fce0-44ce-9ed8-64f18b09f868", "instanceId": 862915256, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "0339555a-974a-4f54-9c4a-82da248a3673"}], "displayName": "0"}, "displayName": "0"}, {"id": "7c543d51-e4f2-4683-9790-8989a63c3d68", "instanceId": 852441310, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775385, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775385, "name": "policy_1_backup-and-storage", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "476afe9e-e372-445c-bb80-06b181af764d", "instanceId": 862912335, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "db0d75fd-c38d-4879-b649-cbb0098a65f1", "instanceId": 862913522, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "2d36d151-f3a7-4251-bf1a-98487d360015", "instanceId": 862914253, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "020aae9c-e5d6-4fcf-8c19-30faedac7213", "instanceId": 852811333, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "83e68a08-20a0-4408-baa7-1bd5a900ea5c", "instanceId": 862915254, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "6a4bd851-fc77-4ecd-b6aa-c355c74be3a1"}], "displayName": "0"}, "displayName": "0"}, {"id": "9226d6a1-c6e0-448d-819b-8c6f1de7bbb7", "instanceId": 852441307, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775379, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775379, "name": "policy_1_collaboration-apps", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "23984bc5-8d80-4861-ab75-e808b610f003", "instanceId": 862912332, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "5a3bbef1-ea65-4a46-8b85-45d73ffa554c", "instanceId": 862913519, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "b868ae98-de93-45bf-810e-6862d2e9f1fe", "instanceId": 862914250, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "35635197-826e-42ae-a21b-ba4423a9ec98", "instanceId": 852811330, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_RELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "a8e4ccf8-a34c-4ccd-bbab-0cf704a1c83a", "instanceId": 862915251, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "7c6ea543-dddc-4e45-b490-1d3a1630f7ef"}], "displayName": "0"}, "displayName": "0"}, {"id": "aa7bceee-2647-44c0-9079-171b72d1a9c0", "instanceId": 852441311, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775387, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775387, "name": "policy_1_general-media", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "73154ba6-b8e6-48d1-82ad-63be0e9418b4", "instanceId": 862912336, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "598ebcd3-1f6f-4ac7-83b4-cd3aaf270a22", "instanceId": 862913523, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "64721121-faae-4213-b9d7-2cd049933d98", "instanceId": 862914254, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "28875721-aa53-4dad-8af1-86ea38e55903", "instanceId": 852811334, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "2519dd10-3dff-4859-b5ff-44ff2dae1354", "instanceId": 862915255, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "ca60f9b3-4c1d-4550-925a-db21dfc524c9"}], "displayName": "0"}, "displayName": "0"}, {"id": "c35b0883-379b-43da-b7d4-c1525b99eb36", "instanceId": 852441309, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775383, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775383, "name": "policy_1_tunneling", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "8030bcd7-3575-486a-b545-881587de528a", "instanceId": 862912334, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "a7ad7043-4622-4a30-ad6c-71c3f6caab0e", "instanceId": 862913521, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "b0576efb-b15a-47d4-b92b-de34ec1ef153", "instanceId": 862914252, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "e7ef5532-420d-45b8-aba4-e7fe0056ca96", "instanceId": 852811332, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "0a003375-3f51-4b82-908f-3ca8abb5de25", "instanceId": 862915253, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "4d71fffb-01fe-4347-baa0-59ff022aec17"}], "displayName": "0"}, "displayName": "0"}, {"id": "c7e53505-3567-41af-af1d-a3bd47aaad2f", "instanceId": 852441308, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775381, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775381, "name": "policy_1_email", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "a2b04154-dc36-4195-90a1-0028fa9b87c5", "instanceId": 862912333, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "b4bc8d3d-e6c4-4642-a050-081265f14094", "instanceId": 862913520, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "e8b0aedf-0f67-478c-aa73-b231376ac68b", "instanceId": 862914251, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "9284d81c-8bfa-492c-b247-9bba5fca1534", "instanceId": 852811331, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "dbe6a833-8e67-4d8a-b93b-5d47ae772a6c", "instanceId": 862915252, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}], "displayName": "0"}, "displayName": "0"}], "version": "1.0"},
+"site_design_noupdate": {"response": [{"id": "5fc3b912-8cb8-4c73-8ef3-97b544af6843", "parentId": "5a9bb391-fb8f-47a5-8dd9-31c6fa7d8289", "name": "FLOOR1_LEVEL1", "nameHierarchy": "Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1", "type": "floor", "floorNumber": 1, "rfModel": "Cubes And Walled Offices", "width": 100.0, "length": 100.0, "height": 10.0, "unitsOfMeasure": "feet"}], "version": "1.0"},
+"Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1_noupdate": {"response": [{"id": "5fc3b912-8cb8-4c73-8ef3-97b544af6843", "parentId": "5a9bb391-fb8f-47a5-8dd9-31c6fa7d8289", "name": "FLOOR1_LEVEL1", "nameHierarchy": "Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1", "type": "floor", "floorNumber": 1, "rfModel": "Cubes And Walled Offices", "width": 100.0, "length": 100.0, "height": 10.0, "unitsOfMeasure": "feet"}]},
+"get_application_policy_queuing_profile_noupdate1": {"response": [{"id": "43329924-f1df-4d41-b4f3-1b93911358c3", "instanceId": 768840254, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "createTime": 1741859335041, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1741859335041, "name": "a5", "namespace": "43329924-f1df-4d41-b4f3-1b93911358c3", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "e3526adb-74b0-4d15-9952-41a78b1f608b", "instanceId": 768903189, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "c8ba1180-26c5-48c4-aa36-9f5ec7d815d1", "instanceId": 768907348, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "e1c79240-6d7e-4b6d-9de2-55ba4df85aae", "instanceId": 768907349, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "872ff518-c685-4143-b1a8-f5b11f0336f2", "instanceId": 768907350, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "2ae407d0-482b-4948-b30b-9e2fc586edf5", "instanceId": 768907351, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "b2999333-c7f3-47f3-be96-6e8cf37e1376", "instanceId": 768907344, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "91334031-ef9e-4720-bb9e-f3fecbaa34aa", "instanceId": 768907345, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "f90d9863-6d97-4cfb-8ccd-27a60cca1f08", "instanceId": 768907346, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "89edce6c-c1b7-43d0-a1a8-eb15c4c0b6dc", "instanceId": 768907347, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "498cfe22-eb03-49de-875f-0b29050b28b1", "instanceId": 768907343, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "b6112849-eb7d-47e6-b9ab-f547744521f0", "instanceId": 768907352, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "f3c49c93-6b8c-47ae-8ce8-36417cc29c47", "instanceId": 768907353, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "008796aa-5948-4c7e-83b1-b38a62158aae", "instanceId": 768907354, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}], "displayName": "0"}, {"id": "af1605d8-edac-43c6-b20d-7ef99f4afb57", "instanceId": 768903190, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "c787ef12-0588-41ba-a247-8b44fbe23256", "instanceId": 768904252, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "b653da4b-744e-48ae-9180-4567a12d97f4", "instanceId": 775056674, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "772b5664-0e67-49c7-8f0d-4da805e4c218", "instanceId": 775056675, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "d35b65f1-401d-433e-b9a9-762adfaf3f2d", "instanceId": 775056673, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "ea455975-487d-4a5f-8f94-a6f463e7c78e", "instanceId": 775056678, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "00ae1d57-15a4-46fa-9d64-09afbb255a5d", "instanceId": 775056679, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "e78f6283-d5e6-475d-8d91-fb0088cc8d1f", "instanceId": 775056676, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "73c5f10b-e609-48c4-b34f-3c5f5c80309f", "instanceId": 775056677, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "d34a91a9-fdbb-4a6b-b804-e94ca2a4ce89", "instanceId": 775056682, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "284a9e01-4b67-435a-9dc8-3f2758979e87", "instanceId": 775056683, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f6ab4791-ef6b-49b5-b85b-9a1b4e203a12", "instanceId": 775056680, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "9f75f59e-add7-4984-ae38-697e87f8df3e", "instanceId": 775056681, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "ad480a0e-a9fc-40a4-9be0-60123041b56b", "instanceId": 775056684, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_noupdate1": {"response": [{"id": "6006d257-89f2-44f3-9739-861e13a99763", "instanceId": 852441306, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775377, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775377, "name": "policy_1_a5", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "aff022fb-3b2f-49cd-8ef0-105883845beb", "instanceId": 862912331, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "bc7a222e-c8d9-4735-8cf7-13a29160bd30", "instanceId": 862913518, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contract": {"idRef": "43329924-f1df-4d41-b4f3-1b93911358c3"}, "contractList": [], "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "displayName": "0"}, {"id": "6cb5141f-080f-4419-9b0f-55b098f84360", "instanceId": 852441312, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775388, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775388, "name": "policy_1_file-sharing", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "46f0ca86-570f-4be9-a20f-8b3c98d3a8a4", "instanceId": 862912337, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "7cf8770e-e6cb-4b69-b51c-9bbd742114ee", "instanceId": 862913524, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "0267d287-48b9-48f8-a0e0-407f22ee1810", "instanceId": 862914255, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "9de236df-ae61-4836-9a75-6303da22bd94", "instanceId": 852811335, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "4aefc84a-fce0-44ce-9ed8-64f18b09f868", "instanceId": 862915256, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "0339555a-974a-4f54-9c4a-82da248a3673"}], "displayName": "0"}, "displayName": "0"}, {"id": "7c543d51-e4f2-4683-9790-8989a63c3d68", "instanceId": 852441310, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775385, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775385, "name": "policy_1_backup-and-storage", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "476afe9e-e372-445c-bb80-06b181af764d", "instanceId": 862912335, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "db0d75fd-c38d-4879-b649-cbb0098a65f1", "instanceId": 862913522, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "2d36d151-f3a7-4251-bf1a-98487d360015", "instanceId": 862914253, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "020aae9c-e5d6-4fcf-8c19-30faedac7213", "instanceId": 852811333, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "83e68a08-20a0-4408-baa7-1bd5a900ea5c", "instanceId": 862915254, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "6a4bd851-fc77-4ecd-b6aa-c355c74be3a1"}], "displayName": "0"}, "displayName": "0"}, {"id": "9226d6a1-c6e0-448d-819b-8c6f1de7bbb7", "instanceId": 852441307, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775379, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775379, "name": "policy_1_collaboration-apps", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "23984bc5-8d80-4861-ab75-e808b610f003", "instanceId": 862912332, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "5a3bbef1-ea65-4a46-8b85-45d73ffa554c", "instanceId": 862913519, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "b868ae98-de93-45bf-810e-6862d2e9f1fe", "instanceId": 862914250, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "35635197-826e-42ae-a21b-ba4423a9ec98", "instanceId": 852811330, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_RELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "a8e4ccf8-a34c-4ccd-bbab-0cf704a1c83a", "instanceId": 862915251, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "7c6ea543-dddc-4e45-b490-1d3a1630f7ef"}], "displayName": "0"}, "displayName": "0"}, {"id": "aa7bceee-2647-44c0-9079-171b72d1a9c0", "instanceId": 852441311, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775387, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775387, "name": "policy_1_general-media", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "73154ba6-b8e6-48d1-82ad-63be0e9418b4", "instanceId": 862912336, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "598ebcd3-1f6f-4ac7-83b4-cd3aaf270a22", "instanceId": 862913523, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "64721121-faae-4213-b9d7-2cd049933d98", "instanceId": 862914254, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "28875721-aa53-4dad-8af1-86ea38e55903", "instanceId": 852811334, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "2519dd10-3dff-4859-b5ff-44ff2dae1354", "instanceId": 862915255, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "ca60f9b3-4c1d-4550-925a-db21dfc524c9"}], "displayName": "0"}, "displayName": "0"}, {"id": "c35b0883-379b-43da-b7d4-c1525b99eb36", "instanceId": 852441309, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775383, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775383, "name": "policy_1_tunneling", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "8030bcd7-3575-486a-b545-881587de528a", "instanceId": 862912334, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "a7ad7043-4622-4a30-ad6c-71c3f6caab0e", "instanceId": 862913521, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "b0576efb-b15a-47d4-b92b-de34ec1ef153", "instanceId": 862914252, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "e7ef5532-420d-45b8-aba4-e7fe0056ca96", "instanceId": 852811332, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "0a003375-3f51-4b82-908f-3ca8abb5de25", "instanceId": 862915253, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "4d71fffb-01fe-4347-baa0-59ff022aec17"}], "displayName": "0"}, "displayName": "0"}, {"id": "c7e53505-3567-41af-af1d-a3bd47aaad2f", "instanceId": 852441308, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "createTime": 1746773775381, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746773775381, "name": "policy_1_email", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "a2b04154-dc36-4195-90a1-0028fa9b87c5", "instanceId": 862912333, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "b4bc8d3d-e6c4-4642-a050-081265f14094", "instanceId": 862913520, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "groupId": ["5fc3b912-8cb8-4c73-8ef3-97b544af6843"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "e8b0aedf-0f67-478c-aa73-b231376ac68b", "instanceId": 862914251, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "clause": [{"id": "9284d81c-8bfa-492c-b247-9bba5fca1534", "instanceId": 852811331, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "dbe6a833-8e67-4d8a-b93b-5d47ae772a6c", "instanceId": 862915252, "instanceCreatedOn": 1746773775841, "instanceUpdatedOn": 1746773775841, "instanceVersion": 0, "scalableGroup": [{"idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}], "displayName": "0"}, "displayName": "0"}], "version": "1.0"},
+"response5": {
+  "response": "Application Policy(ies) 'policy_1' need no update in Cisco Catalyst Center."},
+
+"playbook_policy_alreadydeleted": [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a5",
+              "clause": [
+                  {
+                      "clause_type": "BUSINESS_RELEVANCE",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "email",
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "backup-and-storage",
+                                  "general-media",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wireds",
+              "name": "policy_1",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_alreadydeleted": {"response": [{"id": "43329924-f1df-4d41-b4f3-1b93911358c3", "instanceId": 768840254, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "createTime": 1741859335041, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1741859335041, "name": "a5", "namespace": "43329924-f1df-4d41-b4f3-1b93911358c3", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "e3526adb-74b0-4d15-9952-41a78b1f608b", "instanceId": 768903189, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "c8ba1180-26c5-48c4-aa36-9f5ec7d815d1", "instanceId": 768907348, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "e1c79240-6d7e-4b6d-9de2-55ba4df85aae", "instanceId": 768907349, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "872ff518-c685-4143-b1a8-f5b11f0336f2", "instanceId": 768907350, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "2ae407d0-482b-4948-b30b-9e2fc586edf5", "instanceId": 768907351, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "b2999333-c7f3-47f3-be96-6e8cf37e1376", "instanceId": 768907344, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "91334031-ef9e-4720-bb9e-f3fecbaa34aa", "instanceId": 768907345, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "f90d9863-6d97-4cfb-8ccd-27a60cca1f08", "instanceId": 768907346, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "89edce6c-c1b7-43d0-a1a8-eb15c4c0b6dc", "instanceId": 768907347, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "498cfe22-eb03-49de-875f-0b29050b28b1", "instanceId": 768907343, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "b6112849-eb7d-47e6-b9ab-f547744521f0", "instanceId": 768907352, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "f3c49c93-6b8c-47ae-8ce8-36417cc29c47", "instanceId": 768907353, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "008796aa-5948-4c7e-83b1-b38a62158aae", "instanceId": 768907354, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}], "displayName": "0"}, {"id": "af1605d8-edac-43c6-b20d-7ef99f4afb57", "instanceId": 768903190, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "c787ef12-0588-41ba-a247-8b44fbe23256", "instanceId": 768904252, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "b653da4b-744e-48ae-9180-4567a12d97f4", "instanceId": 775056674, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "772b5664-0e67-49c7-8f0d-4da805e4c218", "instanceId": 775056675, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "d35b65f1-401d-433e-b9a9-762adfaf3f2d", "instanceId": 775056673, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "ea455975-487d-4a5f-8f94-a6f463e7c78e", "instanceId": 775056678, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "00ae1d57-15a4-46fa-9d64-09afbb255a5d", "instanceId": 775056679, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "e78f6283-d5e6-475d-8d91-fb0088cc8d1f", "instanceId": 775056676, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "73c5f10b-e609-48c4-b34f-3c5f5c80309f", "instanceId": 775056677, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "d34a91a9-fdbb-4a6b-b804-e94ca2a4ce89", "instanceId": 775056682, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "284a9e01-4b67-435a-9dc8-3f2758979e87", "instanceId": 775056683, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f6ab4791-ef6b-49b5-b85b-9a1b4e203a12", "instanceId": 775056680, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "9f75f59e-add7-4984-ae38-697e87f8df3e", "instanceId": 775056681, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "ad480a0e-a9fc-40a4-9be0-60123041b56b", "instanceId": 775056684, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_alreadydeleted": {"response": [], "version": "1.0"},
+"get_application_policy_alreadydeleted1": {"response": [], "version": "1.0"},
+"get_application_policy_queuing_profile_delete1": {"response": [{"id": "43329924-f1df-4d41-b4f3-1b93911358c3", "instanceId": 768840254, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "createTime": 1741859335041, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1741859335041, "name": "a5", "namespace": "43329924-f1df-4d41-b4f3-1b93911358c3", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "e3526adb-74b0-4d15-9952-41a78b1f608b", "instanceId": 768903189, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "c8ba1180-26c5-48c4-aa36-9f5ec7d815d1", "instanceId": 768907348, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "e1c79240-6d7e-4b6d-9de2-55ba4df85aae", "instanceId": 768907349, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "872ff518-c685-4143-b1a8-f5b11f0336f2", "instanceId": 768907350, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "2ae407d0-482b-4948-b30b-9e2fc586edf5", "instanceId": 768907351, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "b2999333-c7f3-47f3-be96-6e8cf37e1376", "instanceId": 768907344, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "91334031-ef9e-4720-bb9e-f3fecbaa34aa", "instanceId": 768907345, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "f90d9863-6d97-4cfb-8ccd-27a60cca1f08", "instanceId": 768907346, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "89edce6c-c1b7-43d0-a1a8-eb15c4c0b6dc", "instanceId": 768907347, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "498cfe22-eb03-49de-875f-0b29050b28b1", "instanceId": 768907343, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "b6112849-eb7d-47e6-b9ab-f547744521f0", "instanceId": 768907352, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "f3c49c93-6b8c-47ae-8ce8-36417cc29c47", "instanceId": 768907353, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "008796aa-5948-4c7e-83b1-b38a62158aae", "instanceId": 768907354, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}], "displayName": "0"}, {"id": "af1605d8-edac-43c6-b20d-7ef99f4afb57", "instanceId": 768903190, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "c787ef12-0588-41ba-a247-8b44fbe23256", "instanceId": 768904252, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "b653da4b-744e-48ae-9180-4567a12d97f4", "instanceId": 775056674, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "772b5664-0e67-49c7-8f0d-4da805e4c218", "instanceId": 775056675, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "d35b65f1-401d-433e-b9a9-762adfaf3f2d", "instanceId": 775056673, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "ea455975-487d-4a5f-8f94-a6f463e7c78e", "instanceId": 775056678, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "00ae1d57-15a4-46fa-9d64-09afbb255a5d", "instanceId": 775056679, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "e78f6283-d5e6-475d-8d91-fb0088cc8d1f", "instanceId": 775056676, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "73c5f10b-e609-48c4-b34f-3c5f5c80309f", "instanceId": 775056677, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "d34a91a9-fdbb-4a6b-b804-e94ca2a4ce89", "instanceId": 775056682, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "284a9e01-4b67-435a-9dc8-3f2758979e87", "instanceId": 775056683, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f6ab4791-ef6b-49b5-b85b-9a1b4e203a12", "instanceId": 775056680, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "9f75f59e-add7-4984-ae38-697e87f8df3e", "instanceId": 775056681, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "ad480a0e-a9fc-40a4-9be0-60123041b56b", "instanceId": 775056684, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_alreadydeleted2": {"response": [], "version": "1.0"},
+"response7": {
+  "response": "Application Polic(ies) 'policy_1' do not exist or are already deleted in Cisco Catalyst Center."},
+
+
+"playbook_application_alreadydeleted": [
+  {
+      "application": [
+          {
+              "name": "application1"
+          }
+      ]
+  }
+],
+"get_applications_v2_alreadydeleted": {"response": [], "version": "1.0"} ,
+"get_applications_v2_alreadydeleted1": {"response": [], "version": "1.0"},
+"get_applications_v2_alreadydeleted2": {"response": [], "version": "1.0"},
+"response8": {
+  "response": "Application(s) 'application1' do not exist or are already deleted in Cisco Catalyst Center."},
+
+"playbook_profile_alreadydeleted": [
+  {
+      "queuing_profile": [
+          {
+              "profile_name": "c8"
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_alreadydeleted1": {"response": [], "version": "1.0"} ,
+"get_application_policy_queuing_profile_alreadydeleted2": {"response": [], "version": "1.0"},
+"get_application_policy_queuing_profile_alreadydeleted3": {"response": [], "version": "1.0"},
+"response9": {
+  "response": "Queuing Profile(s) 'c8' do not exist or are already deleted in Cisco Catalyst Center."},
+
+"playbook_error_4":  [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a11",
+              "clause": [
+                  {
+                      "clause_type": "BUSINESS_RELEVANCEe",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "general-media",
+                                  "email"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wired",
+              "name": "policy_1",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/Chennai/LTTS/FLOOR11"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_error": {"response": [{"id": "8a513646-891e-4318-ba13-3e01ee6452bc", "instanceId": 811838353, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "createTime": 1743128421193, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1743128421193, "name": "a11", "namespace": "8a513646-891e-4318-ba13-3e01ee6452bc", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "31e24d95-1390-4230-924d-43b2735e52c7", "instanceId": 768903602, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "7e7f225b-c1ae-41dd-aa7a-2abb8a24f811", "instanceId": 768904461, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "7d58378b-0e2e-4270-8149-2451f8c90bb4", "instanceId": 811906996, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "1c58eeb1-1964-4572-929a-e3698e12eca5", "instanceId": 811906997, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "917380f2-441f-4a6e-b249-126ad9f036cf", "instanceId": 811906998, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "9a9c4135-053d-4802-a12d-4371ed525f86", "instanceId": 811906999, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "3664a3f4-ab07-4723-a5e9-1c7095002d8b", "instanceId": 811906992, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "0196cb30-f965-4340-b7f5-26e9c5180700", "instanceId": 811906993, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "b3c97465-49a4-4974-ab49-cd8ae3f076b4", "instanceId": 811906994, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "1d58cc25-0d0b-460e-858b-eac3b7479577", "instanceId": 811906995, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "e05ea012-bfef-40cf-a1a2-64e26e4ce20a", "instanceId": 811907000, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "81c4e4a9-8c9f-4246-89db-906556d05ec2", "instanceId": 811907001, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "f7394890-88a2-4fb8-bf9a-dfe862192595", "instanceId": 811907002, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "c4cc9fc7-8f53-4c14-91d6-92e667f0af64", "instanceId": 811907003, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}, {"id": "f9a54ee9-e6b9-4803-a1a2-1b440f43cb4d", "instanceId": 768903603, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "90e3f105-a022-42c5-8426-46964d86a612", "instanceId": 768907876, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "c56c5d11-4c36-4748-b0e4-093d17e898a5", "instanceId": 768907877, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "7bac2b1c-e112-4e16-9e02-aa333f6213c1", "instanceId": 768907878, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "dabb2457-a7d7-4d57-ba56-5ad9114f1fe3", "instanceId": 768907879, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "3e5e3a1d-0589-48fc-8ea9-7d9167467ca7", "instanceId": 768907872, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "d2dbc9ab-3d6b-490b-b66c-79c46e4690e0", "instanceId": 768907873, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "4bf2564e-7ff6-469e-b48d-db956e01e680", "instanceId": 768907874, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "3093e5de-c00a-447c-9884-d5a62351d3ce", "instanceId": 768907875, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "97d3eb68-f857-4575-895b-7f433e8d9a63", "instanceId": 768907871, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f9e94a79-5bd6-47e7-a742-c15b57cf4972", "instanceId": 768907880, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "6b9bef5f-cc13-4bb5-bf57-5f127623a5eb", "instanceId": 768907881, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "5d8db750-593a-4330-844e-169fa96f5356", "instanceId": 768907882, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_error": {"response": [], "version": "1.0"},
+"response10": {
+  "response": "Invalid clause_type: BUSINESS_RELEVANCEE. Must be one of ['APPLICATION_POLICY_KNOBS', 'BUSINESS_RELEVANCE']."},
+
+"playbook_error_5":  [
+  {
+      "application_policy": [
+          {
+              "clause": [
+                  {
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "general-media",
+                                  "email"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wired",
+              "name": "policy_1",
+              "policy_status": "deployed"
+          }
+      ]
+  }
+],
+"get_application_policy_error1": {"response": [], "version": "1.0"},
+"response11": {
+  "response": "Application policy operation failed. The following mandatory parameters are missing or empty: site_names, application_queuing_profile_name."},
+
+"playbook_error_6":  [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a11",
+              "clause": [
+                  {
+                      "clause_type": "",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "general-media",
+                                  "email"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wired",
+              "name": "policy_1",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/Chennai/LTTS/FLOOR11"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_error1": {"response": [{"id": "8a513646-891e-4318-ba13-3e01ee6452bc", "instanceId": 811838353, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "createTime": 1743128421193, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1743128421193, "name": "a11", "namespace": "8a513646-891e-4318-ba13-3e01ee6452bc", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "31e24d95-1390-4230-924d-43b2735e52c7", "instanceId": 768903602, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "7e7f225b-c1ae-41dd-aa7a-2abb8a24f811", "instanceId": 768904461, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "7d58378b-0e2e-4270-8149-2451f8c90bb4", "instanceId": 811906996, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "1c58eeb1-1964-4572-929a-e3698e12eca5", "instanceId": 811906997, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "917380f2-441f-4a6e-b249-126ad9f036cf", "instanceId": 811906998, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "9a9c4135-053d-4802-a12d-4371ed525f86", "instanceId": 811906999, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "3664a3f4-ab07-4723-a5e9-1c7095002d8b", "instanceId": 811906992, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "0196cb30-f965-4340-b7f5-26e9c5180700", "instanceId": 811906993, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "b3c97465-49a4-4974-ab49-cd8ae3f076b4", "instanceId": 811906994, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "1d58cc25-0d0b-460e-858b-eac3b7479577", "instanceId": 811906995, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "e05ea012-bfef-40cf-a1a2-64e26e4ce20a", "instanceId": 811907000, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "81c4e4a9-8c9f-4246-89db-906556d05ec2", "instanceId": 811907001, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "f7394890-88a2-4fb8-bf9a-dfe862192595", "instanceId": 811907002, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "c4cc9fc7-8f53-4c14-91d6-92e667f0af64", "instanceId": 811907003, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}, {"id": "f9a54ee9-e6b9-4803-a1a2-1b440f43cb4d", "instanceId": 768903603, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "90e3f105-a022-42c5-8426-46964d86a612", "instanceId": 768907876, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "c56c5d11-4c36-4748-b0e4-093d17e898a5", "instanceId": 768907877, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "7bac2b1c-e112-4e16-9e02-aa333f6213c1", "instanceId": 768907878, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "dabb2457-a7d7-4d57-ba56-5ad9114f1fe3", "instanceId": 768907879, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "3e5e3a1d-0589-48fc-8ea9-7d9167467ca7", "instanceId": 768907872, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "d2dbc9ab-3d6b-490b-b66c-79c46e4690e0", "instanceId": 768907873, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "4bf2564e-7ff6-469e-b48d-db956e01e680", "instanceId": 768907874, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "3093e5de-c00a-447c-9884-d5a62351d3ce", "instanceId": 768907875, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "97d3eb68-f857-4575-895b-7f433e8d9a63", "instanceId": 768907871, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f9e94a79-5bd6-47e7-a742-c15b57cf4972", "instanceId": 768907880, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "6b9bef5f-cc13-4bb5-bf57-5f127623a5eb", "instanceId": 768907881, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "5d8db750-593a-4330-844e-169fa96f5356", "instanceId": 768907882, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_error2": {"response": [], "version": "1.0"},
+"response12": {
+  "response": "Invalid clause_type: None or empty. Must be one of ['APPLICATION_POLICY_KNOBS', 'BUSINESS_RELEVANCE']."},
+
+"playbook_error_7":  [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a11",
+              "clause": [
+                  {
+                      "clause_type": "BUSINESS_RELEVANCE",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "general-media",
+                                  "email",
+                                  "local-services"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "tunneling"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps",
+                                  "file-sharing"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wired",
+              "name": "policy_1",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/Chennai/LTTS/FLOOR11"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_error2": {"response": [{"id": "8a513646-891e-4318-ba13-3e01ee6452bc", "instanceId": 811838353, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "createTime": 1743128421193, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1743128421193, "name": "a11", "namespace": "8a513646-891e-4318-ba13-3e01ee6452bc", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "31e24d95-1390-4230-924d-43b2735e52c7", "instanceId": 768903602, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "7e7f225b-c1ae-41dd-aa7a-2abb8a24f811", "instanceId": 768904461, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "7d58378b-0e2e-4270-8149-2451f8c90bb4", "instanceId": 811906996, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "1c58eeb1-1964-4572-929a-e3698e12eca5", "instanceId": 811906997, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "917380f2-441f-4a6e-b249-126ad9f036cf", "instanceId": 811906998, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "9a9c4135-053d-4802-a12d-4371ed525f86", "instanceId": 811906999, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "3664a3f4-ab07-4723-a5e9-1c7095002d8b", "instanceId": 811906992, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "0196cb30-f965-4340-b7f5-26e9c5180700", "instanceId": 811906993, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "b3c97465-49a4-4974-ab49-cd8ae3f076b4", "instanceId": 811906994, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "1d58cc25-0d0b-460e-858b-eac3b7479577", "instanceId": 811906995, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "e05ea012-bfef-40cf-a1a2-64e26e4ce20a", "instanceId": 811907000, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "81c4e4a9-8c9f-4246-89db-906556d05ec2", "instanceId": 811907001, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "f7394890-88a2-4fb8-bf9a-dfe862192595", "instanceId": 811907002, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "c4cc9fc7-8f53-4c14-91d6-92e667f0af64", "instanceId": 811907003, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}, {"id": "f9a54ee9-e6b9-4803-a1a2-1b440f43cb4d", "instanceId": 768903603, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "90e3f105-a022-42c5-8426-46964d86a612", "instanceId": 768907876, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "c56c5d11-4c36-4748-b0e4-093d17e898a5", "instanceId": 768907877, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "7bac2b1c-e112-4e16-9e02-aa333f6213c1", "instanceId": 768907878, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "dabb2457-a7d7-4d57-ba56-5ad9114f1fe3", "instanceId": 768907879, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "3e5e3a1d-0589-48fc-8ea9-7d9167467ca7", "instanceId": 768907872, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "d2dbc9ab-3d6b-490b-b66c-79c46e4690e0", "instanceId": 768907873, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "4bf2564e-7ff6-469e-b48d-db956e01e680", "instanceId": 768907874, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "3093e5de-c00a-447c-9884-d5a62351d3ce", "instanceId": 768907875, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "97d3eb68-f857-4575-895b-7f433e8d9a63", "instanceId": 768907871, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f9e94a79-5bd6-47e7-a742-c15b57cf4972", "instanceId": 768907880, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "6b9bef5f-cc13-4bb5-bf57-5f127623a5eb", "instanceId": 768907881, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "5d8db750-593a-4330-844e-169fa96f5356", "instanceId": 768907882, "instanceCreatedOn": 1743128421201, "instanceUpdatedOn": 1743128421201, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_error3": {"response": [{"id": "0ce980a8-aff1-435e-99ea-0385969564d2", "instanceId": 852441318, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970576, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970576, "name": "policy_1_collaboration-apps", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "ec2e899b-c4ee-4b31-b5b9-32e8ab3ee8e3", "instanceId": 862912343, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "8cfba70d-93dc-4dd5-b71e-ad7fd27251fd", "instanceId": 862913530, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "088f2acf-5912-4aa2-b69f-cef6bdf9e483", "instanceId": 862914259, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "clause": [{"id": "d15a510d-91ab-4e9d-8643-864d9b1b45bb", "instanceId": 852811339, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "e18ab274-2ec7-4309-9002-f46ead09cdca", "instanceId": 862915260, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "scalableGroup": [{"idRef": "7c6ea543-dddc-4e45-b490-1d3a1630f7ef"}], "displayName": "0"}, "displayName": "0"}, {"id": "46224510-a9c4-48a6-b49c-b036f9972cc2", "instanceId": 852441319, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970578, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970578, "name": "policy_1_file-sharing", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "bfeeb4b6-0011-46b8-a413-4effb96d55b8", "instanceId": 862912344, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "1d0afa98-36bd-41dc-a169-73f851045c09", "instanceId": 862913531, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "5382ed30-0620-4802-9a3c-f3d90c579059", "instanceId": 862914260, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "clause": [{"id": "a6f040e3-9581-404c-b0fc-f6f94202339b", "instanceId": 852811340, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "DEFAULT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "c360231a-efc4-4fe0-937d-68ad0020d9f9", "instanceId": 862915261, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "scalableGroup": [{"idRef": "0339555a-974a-4f54-9c4a-82da248a3673"}], "displayName": "0"}, "displayName": "0"}, {"id": "58bb5ddf-991b-4efb-8ca6-ad8b6a0e249a", "instanceId": 852441316, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970572, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970572, "name": "policy_1_email", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "d549299e-eb2f-4918-b5bc-8ee239a791df", "instanceId": 862912341, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "5aca8510-921a-4d50-aaf8-5c826917fb59", "instanceId": 862913528, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "a913054b-7fa6-4e76-97a9-c6c9f1a1e13c", "instanceId": 862914257, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "clause": [{"id": "aa654b9e-dea9-4afa-9fd9-bef86562d154", "instanceId": 852811337, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_RELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "c2f7ace6-e3f0-40b0-91ca-1a4b3d6cb519", "instanceId": 862915258, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "scalableGroup": [{"idRef": "5b428b73-00e6-4f3a-8d6c-2cbf5eb8981a"}], "displayName": "0"}, "displayName": "0"}, {"id": "62e51f49-032b-4966-a940-d7d6cc8f0969", "instanceId": 852441317, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970574, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970574, "name": "policy_1_tunneling", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "4e1d23a0-af45-47ed-a7c5-c1215e634f65", "instanceId": 862912342, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "d9c0f76d-2ff5-42eb-82ae-db505ae9164a", "instanceId": 862913529, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "f380d5b1-876e-493d-9507-d479581e5712", "instanceId": 862914258, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "clause": [{"id": "cdb11f1d-7cb8-4b67-aef0-10f469a03fd1", "instanceId": 852811338, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_IRRELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "5dc82bc9-ffb7-4bf9-b3df-c3eb28427197", "instanceId": 862915259, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "scalableGroup": [{"idRef": "4d71fffb-01fe-4347-baa0-59ff022aec17"}], "displayName": "0"}, "displayName": "0"}, {"id": "bf6925a2-0726-465f-9377-991d76045b31", "instanceId": 852441315, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970570, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970570, "name": "policy_1_general-media", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "3b624c20-7e1e-4d09-938d-a2594b92e580", "instanceId": 862912340, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "74cc0b14-e751-4467-8612-4ff760bbd30e", "instanceId": 862913527, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contractList": [], "exclusiveContract": {"id": "5f84b9f3-5c9c-458a-9230-fb5f589a532b", "instanceId": 862914256, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "clause": [{"id": "57e2ba64-70fb-4f93-a7d4-300484c5d166", "instanceId": 852811336, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "priority": 1, "type": "BUSINESS_RELEVANCE", "relevanceLevel": "BUSINESS_RELEVANT", "displayName": "0"}], "displayName": "0"}, "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "producer": {"id": "871826c7-866e-434d-88e2-1531cf83a570", "instanceId": 862915257, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "scalableGroup": [{"idRef": "ca60f9b3-4c1d-4550-925a-db21dfc524c9"}], "displayName": "0"}, "displayName": "0"}, {"id": "f2d46edc-c2ac-4f6d-aac3-f848945ce656", "instanceId": 852441314, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "createTime": 1746784970567, "deployed": false, "isSeeded": false, "isStale": false, "lastUpdateTime": 1746784970567, "name": "policy_1_a11", "namespace": "policy:application:policy_1", "provisioningState": "UNKNOWN", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "policy", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "deletePolicyStatus": "NONE", "internal": false, "isDeleted": false, "isEnabled": true, "isScopeStale": false, "iseReserved": false, "policyScope": "policy_1", "policyStatus": "ENABLED", "priority": 100, "pushed": false, "advancedPolicyScope": {"id": "15ec990f-290f-49e5-978f-c3dc887eb55b", "instanceId": 862912339, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "name": "policy_1", "advancedPolicyScopeElement": [{"id": "be7b6e40-0958-448a-a4aa-63be8d6804c1", "instanceId": 862913526, "instanceCreatedOn": 1746784971065, "instanceUpdatedOn": 1746784971065, "instanceVersion": 0, "groupId": ["03072c33-bd11-4914-9c0e-3c53379b2813"], "ssid": [], "displayName": "0"}], "displayName": "0"}, "contract": {"idRef": "8a513646-891e-4318-ba13-3e01ee6452bc"}, "contractList": [], "identitySource": {"id": "9b30e94e-8057-4dcd-876a-2740eef2e0dd", "instanceId": 320876556, "instanceCreatedOn": 1729608226117, "instanceUpdatedOn": 1729608226117, "instanceVersion": 0, "state": "INACTIVE", "type": "APIC_EM", "displayName": "320876556"}, "displayName": "0"}], "version": "1.0"},
+"site_design_error": {"response": [{"id": "03072c33-bd11-4914-9c0e-3c53379b2813", "parentId": "c3293908-c136-45b9-b74f-d5dfaabb26a9", "name": "FLOOR11", "nameHierarchy": "Global/Chennai/LTTS/FLOOR11", "type": "floor", "floorNumber": 1, "rfModel": "Cubes And Walled Offices", "width": 177.0, "length": 171.0, "height": 10.0, "unitsOfMeasure": "feet"}], "version": "1.0"},
+"Global/Chennai/LTTS/FLOOR11": {"response": [{"id": "03072c33-bd11-4914-9c0e-3c53379b2813", "parentId": "c3293908-c136-45b9-b74f-d5dfaabb26a9", "name": "FLOOR11", "nameHierarchy": "Global/Chennai/LTTS/FLOOR11", "type": "floor", "floorNumber": 1, "rfModel": "Cubes And Walled Offices", "width": 177.0, "length": 171.0, "height": 10.0, "unitsOfMeasure": "feet"}]},
+"response13": {
+  "response": "no extra application sets can be added to the application policy"},
+
+"playbook_error_8": [
+  {
+      "application_policy": [
+          {
+              "application_queuing_profile_name": "a5",
+              "clause": [
+                  {
+                      "clause_type": "BUSINESS_RELEVANCE",
+                      "relevance_details": [
+                          {
+                              "application_set_name": [
+                                  "file-sharing"
+                              ],
+                              "relevance": "BUSINESS_RELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "email",
+                                  "backup-and-storage"
+                              ],
+                              "relevance": "BUSINESS_IRRELEVANT"
+                          },
+                          {
+                              "application_set_name": [
+                                  "collaboration-apps",
+                                  "tunneling",
+                                  "general-media"
+                              ],
+                              "relevance": "DEFAULT"
+                          }
+                      ]
+                  }
+              ],
+              "device_type": "wireless",
+              "name": "Policy_3",
+              "policy_status": "deployed",
+              "site_names": [
+                  "Global/AB_Test/AB_Bgl3"
+              ]
+          }
+      ]
+  }
+],
+"get_application_policy_queuing_profile_error4": {"response": [{"id": "43329924-f1df-4d41-b4f3-1b93911358c3", "instanceId": 768840254, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "createTime": 1741859335041, "deployed": false, "description": "Cisco Validated Design Queuing Profile", "isSeeded": false, "isStale": false, "lastUpdateTime": 1741859335041, "name": "a5", "namespace": "43329924-f1df-4d41-b4f3-1b93911358c3", "provisioningState": "DEFINED", "qualifier": "application", "resourceVersion": 0, "targetIdList": [], "type": "contract", "cfsChangeInfo": [], "customProvisions": [], "externalIntentSourceInfos": [], "genId": 0, "internal": false, "isDeleted": false, "iseReserved": false, "pushed": false, "clause": [{"id": "e3526adb-74b0-4d15-9952-41a78b1f608b", "instanceId": 768903189, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "DSCP_CUSTOMIZATION", "tcDscpSettings": [{"id": "c8ba1180-26c5-48c4-aa36-9f5ec7d815d1", "instanceId": 768907348, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "10", "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "e1c79240-6d7e-4b6d-9de2-55ba4df85aae", "instanceId": 768907349, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "18", "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "872ff518-c685-4143-b1a8-f5b11f0336f2", "instanceId": 768907350, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "0", "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "2ae407d0-482b-4948-b30b-9e2fc586edf5", "instanceId": 768907351, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "34", "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "b2999333-c7f3-47f3-be96-6e8cf37e1376", "instanceId": 768907344, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "16", "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "91334031-ef9e-4720-bb9e-f3fecbaa34aa", "instanceId": 768907345, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "48", "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "f90d9863-6d97-4cfb-8ccd-27a60cca1f08", "instanceId": 768907346, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "8", "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "89edce6c-c1b7-43d0-a1a8-eb15c4c0b6dc", "instanceId": 768907347, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "24", "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "498cfe22-eb03-49de-875f-0b29050b28b1", "instanceId": 768907343, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "46", "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "b6112849-eb7d-47e6-b9ab-f547744521f0", "instanceId": 768907352, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "40", "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}, {"id": "f3c49c93-6b8c-47ae-8ce8-36417cc29c47", "instanceId": 768907353, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "32", "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "008796aa-5948-4c7e-83b1-b38a62158aae", "instanceId": 768907354, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "dscp": "26", "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}], "displayName": "0"}, {"id": "af1605d8-edac-43c6-b20d-7ef99f4afb57", "instanceId": 768903190, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "priority": 1, "type": "BANDWIDTH", "isCommonBetweenAllInterfaceSpeeds": true, "interfaceSpeedBandwidthClauses": [{"id": "c787ef12-0588-41ba-a247-8b44fbe23256", "instanceId": 768904252, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "interfaceSpeed": "ALL", "tcBandwidthSettings": [{"id": "b653da4b-744e-48ae-9180-4567a12d97f4", "instanceId": 775056674, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 1, "trafficClass": "SCAVENGER", "displayName": "0"}, {"id": "772b5664-0e67-49c7-8f0d-4da805e4c218", "instanceId": 775056675, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 3, "trafficClass": "NETWORK_CONTROL", "displayName": "0"}, {"id": "d35b65f1-401d-433e-b9a9-762adfaf3f2d", "instanceId": 775056673, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 4, "trafficClass": "BULK_DATA", "displayName": "0"}, {"id": "ea455975-487d-4a5f-8f94-a6f463e7c78e", "instanceId": 775056678, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 13, "trafficClass": "REAL_TIME_INTERACTIVE", "displayName": "0"}, {"id": "00ae1d57-15a4-46fa-9d64-09afbb255a5d", "instanceId": 775056679, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "OPS_ADMIN_MGMT", "displayName": "0"}, {"id": "e78f6283-d5e6-475d-8d91-fb0088cc8d1f", "instanceId": 775056676, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 25, "trafficClass": "BEST_EFFORT", "displayName": "0"}, {"id": "73c5f10b-e609-48c4-b34f-3c5f5c80309f", "instanceId": 775056677, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_CONFERENCING", "displayName": "0"}, {"id": "d34a91a9-fdbb-4a6b-b804-e94ca2a4ce89", "instanceId": 775056682, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "VOIP_TELEPHONY", "displayName": "0"}, {"id": "284a9e01-4b67-435a-9dc8-3f2758979e87", "instanceId": 775056683, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "TRANSACTIONAL_DATA", "displayName": "0"}, {"id": "f6ab4791-ef6b-49b5-b85b-9a1b4e203a12", "instanceId": 775056680, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "MULTIMEDIA_STREAMING", "displayName": "0"}, {"id": "9f75f59e-add7-4984-ae38-697e87f8df3e", "instanceId": 775056681, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 2, "trafficClass": "SIGNALING", "displayName": "0"}, {"id": "ad480a0e-a9fc-40a4-9be0-60123041b56b", "instanceId": 775056684, "instanceCreatedOn": 1741859335050, "instanceUpdatedOn": 1741859335050, "instanceVersion": 0, "bandwidthPercentage": 10, "trafficClass": "BROADCAST_VIDEO", "displayName": "0"}], "displayName": "0"}], "displayName": "0"}], "contractClassifier": [], "displayName": "0"}], "version": "1.0"},
+"get_application_policy_error4": {"response": [], "version": "1.0"},
+"site_design_error1": {"response": [{"id": "7d591827-984b-4eb5-8496-bbac9b2f10e0", "parentId": "4e7815d1-e33a-465c-a8b7-d5d4449640a7", "name": "AB_Bgl3", "nameHierarchy": "Global/AB_Test/AB_Bgl3", "type": "building", "latitude": 12.912339, "longitude": 77.63813, "address": "HSR Layout, Bengaluru, Bengaluru Urban, Karnataka, India", "country": "India"}], "version": "1.0"},
+"Global/AB_Test/AB_Bgl3_error": {"response": [{"id": "7d591827-984b-4eb5-8496-bbac9b2f10e0", "parentId": "4e7815d1-e33a-465c-a8b7-d5d4449640a7", "name": "AB_Bgl3", "nameHierarchy": "Global/AB_Test/AB_Bgl3", "type": "building", "latitude": 12.912339, "longitude": 77.63813, "address": "HSR Layout, Bengaluru, Bengaluru Urban, Karnataka, India", "country": "India"}]},
+"response14": {
+  "response": "SSID is required for wireless devices"}
 }

--- a/tests/unit/modules/dnac/test_application_policy_workflow_manager.py
+++ b/tests/unit/modules/dnac/test_application_policy_workflow_manager.py
@@ -38,19 +38,32 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
     playbook_create_policy_wired_error = test_data.get("playbook_create_policy_wired_error")
     playbook_for_application_queuing_profile_delete = test_data.get("playbook_for_application_queuing_profile_delete")
     playbook_for_application_policy_update = test_data.get("playbook_for_application_policy_update")
-    playbook_for_application_policy_update_wireless = test_data.get("playbook_for_application_policy_update_wireless")
     playbook_delete_application = test_data.get("playbook_delete_application")
     playbook_for_queuing_profiletrue_noupdate = test_data.get("playbook_for_queuing_profiletrue_noupdate")
     playbook_for_profile_dscp = test_data.get("playbook_for_profile_dscp")
     playbook_dscp_update = test_data.get("playbook_dscp_update")
     playbook_noprofname = test_data.get("playbook_noprofname")
-    playbook_failure_application = test_data.get("playbook_failure_application")
     playbook_failure_profile = test_data.get("playbook_failure_profile")
     playbook_profile_namedesc_update = test_data.get("playbook_profile_namedesc_update")
     playbook_create_application_servername = test_data.get("playbook_create_application_servername")
     playbook_create_application_serverip = test_data.get("playbook_create_application_serverip")
     playbook_update_application_serveriptoname = test_data.get("playbook_update_application_serveriptoname")
     playbook_update_application_nametourl = test_data.get("playbook_update_application_nametourl")
+    playbook_multiple_profile_delete = test_data.get("playbook_multiple_profile_delete")
+    playbook_application_delete = test_data.get("playbook_application_delete")
+    playbook_error_1 = test_data.get("playbook_error_1")
+    playbook_error_2 = test_data.get("playbook_error_2")
+    playbook_error_3 = test_data.get("playbook_error_3")
+    playbook_application_noupdate = test_data.get("playbook_application_noupdate")
+    playbook_policy_noupdate = test_data.get("playbook_policy_noupdate")
+    playbook_policy_alreadydeleted = test_data.get("playbook_policy_alreadydeleted")
+    playbook_application_alreadydeleted = test_data.get("playbook_application_alreadydeleted")
+    playbook_profile_alreadydeleted = test_data.get("playbook_profile_alreadydeleted")
+    playbook_error_4 = test_data.get("playbook_error_4")
+    playbook_error_5 = test_data.get("playbook_error_5")
+    playbook_error_6 = test_data.get("playbook_error_6")
+    playbook_error_7 = test_data.get("playbook_error_7")
+    playbook_error_8 = test_data.get("playbook_error_8")
 
     def setUp(self):
         super(TestDnacApplicationPolicyWorkflowManager, self).setUp()
@@ -192,13 +205,6 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
                 self.test_data.get("delete_application_response")
             ]
 
-        elif "playbook_failure_application" in self._testMethodName:
-            self.run_dnac_exec.side_effect = [
-                self.test_data.get("get_applications_10"),
-                self.test_data.get("application_set"),
-                self.test_data.get("failure_application_response"),
-            ]
-
         elif "playbook_failure_profile" in self._testMethodName:
             self.run_dnac_exec.side_effect = [
                 self.test_data.get("get_applications_profile"),
@@ -223,7 +229,6 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
                 self.test_data.get("get_application_policy_queuing_profile_82"),
                 self.test_data.get("get_application_policy_83"),
                 self.test_data.get("create_policy_wired_response"),
-
             ]
 
         elif "playbook_profile_namedesc_update" in self._testMethodName:
@@ -285,6 +290,125 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
                 self.test_data.get("get_applications_36"),
                 self.test_data.get("get_application_sets_36"),
                 self.test_data.get("update_application_nametourl"),
+            ]
+
+        elif "playbook_multiple_profile_delete" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_delete"),
+                self.test_data.get("get_application_policy_queuing_profile_delete2"),
+                self.test_data.get("delete_application_policy_queuing_profile_1"),
+                self.test_data.get("Task_Details_delete"),
+                self.test_data.get("Task_Details_delete1"),
+                self.test_data.get("get_application_policy_queuing_profile_delete4"),
+                self.test_data.get("delete_profile_response"),
+            ]
+
+        elif "playbook_application_delete" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_applications_v2_delete"),
+                self.test_data.get("get_applications_v2_delete1"),
+                self.test_data.get("delete_application_v2"),
+                self.test_data.get("TaskDetails"),
+                self.test_data.get("TaskDetails1"),
+                self.test_data.get("get_applications_v2_"),
+                self.test_data.get("response"),
+            ]
+
+        elif "playbook_error_1" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("response1"),
+            ]
+
+        elif "playbook_error_2" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("response1"),
+            ]
+
+        elif "playbook_error_3" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("response3"),
+            ]
+
+        elif "playbook_application_noupdate" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_applications_v2_noupdate"),
+                self.test_data.get("get_application_sets_noupdate"),
+                self.test_data.get("get_applications_v2_noupdate1"),
+                self.test_data.get("get_application_sets_noupdate1"),
+                self.test_data.get("response4"),
+            ]
+
+        elif "playbook_policy_noupdate" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_noupdate"),
+                self.test_data.get("get_application_policy_noupdate"),
+                self.test_data.get("site_design_noupdate"),
+                self.test_data.get("Global/USA/San Jose/BLDG23/FLOOR1_LEVEL1_noupdate"),
+                self.test_data.get("get_application_policy_queuing_profile_noupdate1"),
+                self.test_data.get("get_application_policy_noupdate1"),
+                self.test_data.get("response5"),
+            ]
+
+        elif "playbook_policy_alreadydeleted" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_alreadydeleted"),
+                self.test_data.get("get_application_policy_alreadydeleted"),
+                self.test_data.get("get_application_policy_alreadydeleted1"),
+                self.test_data.get("get_application_policy_queuing_profile_delete1"),
+                self.test_data.get("get_application_policy_alreadydeleted2"),
+                self.test_data.get("response7"),
+            ]
+
+        elif "playbook_application_alreadydeleted" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_alreadydeleted"),
+                self.test_data.get("get_applications_v2_alreadydeleted"),
+                self.test_data.get("response8"),
+            ]
+
+        elif "playbook_profile_alreadydeleted" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_alreadydeleted1"),
+                self.test_data.get("get_application_policy_queuing_profile_alreadydeleted2"),
+                self.test_data.get("response9"),
+            ]
+
+        elif "playbook_error_4" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_error"),
+                self.test_data.get("get_application_policy_error"),
+                self.test_data.get("response10"),
+            ]
+
+        elif "playbook_error_5" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_error1"),
+                self.test_data.get("response11"),
+            ]
+
+        elif "playbook_error_6" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_error1"),
+                self.test_data.get("get_application_policy_error2"),
+                self.test_data.get("response12"),
+            ]
+
+        elif "playbook_error_7" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_error2"),
+                self.test_data.get("get_application_policy_error3"),
+                self.test_data.get("site_design_error"),
+                self.test_data.get("Global/Chennai/LTTS/FLOOR11"),
+                self.test_data.get("response13"),
+            ]
+
+        elif "playbook_error_8" in self._testMethodName:
+            self.run_dnac_exec.side_effect = [
+                self.test_data.get("get_application_policy_queuing_profile_error4"),
+                self.test_data.get("get_application_policy_error4"),
+                self.test_data.get("site_design_error1"),
+                self.test_data.get("Global/AB_Test/AB_Bgl3_error"),
+                self.test_data.get("response14"),
             ]
 
     def test_application_policy_workflow_manager_playbook_create_profile(self):
@@ -519,7 +643,7 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
         print(result)
         self.assertEqual(
             result.get("response"),
-            "Application Policie(s) 'policy_1' deleted successfully from Cisco Catalyst Center."
+            "Application Policy(ies) 'policy_1' deleted successfully from Cisco Catalyst Center."
         )
 
     def test_application_policy_workflow_manager_playbook_for_queuing_profiletrue_noupdate(self):
@@ -786,4 +910,394 @@ class TestDnacApplicationPolicyWorkflowManager(TestDnacModule):
         self.assertEqual(
             result.get("response"),
             "Application(s) 'application_1_new' updated successfully in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_multiple_profile_delete(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="deleted",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_multiple_profile_delete
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Queuing Profile(s) 'b5' deleted successfully from Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_application_delete(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="deleted",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_application_delete
+            )
+        )
+        result = self.execute_module(changed=True, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application(s) 'application1' deleted successfully from Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_1(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_1
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "'queuing_profile' should be a list, found: <class 'dict'>"
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_2(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_2
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "At least one of the following parameters must be specified in the playbook: queuing_profile, application, application_policy."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_3(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_3
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "'application_policy' should be a list, found: <class 'dict'>"
+        )
+
+    def test_application_policy_workflow_manager_playbook_application_noupdate(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_application_noupdate
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application(s) 'application1' need no update in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_policy_noupdate(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_policy_noupdate
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application Policy(ies) 'policy_1' need no update in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_policy_alreadydeleted(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="deleted",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_policy_alreadydeleted
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application Policy(ies) 'policy_1' do not exist or are already deleted in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_application_alreadydeleted(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="deleted",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_application_alreadydeleted
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application(s) 'application1' do not exist or are already deleted in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_profile_alreadydeleted(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="deleted",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_profile_alreadydeleted
+            )
+        )
+        result = self.execute_module(changed=False, failed=False)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Queuing Profile(s) 'c8' do not exist or are already deleted in Cisco Catalyst Center."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_4(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_4
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Invalid clause_type: BUSINESS_RELEVANCEE. Must be one of ['APPLICATION_POLICY_KNOBS', 'BUSINESS_RELEVANCE']."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_5(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_5
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Application policy operation failed. The following mandatory parameters are missing or empty: site_names, application_queuing_profile_name."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_6(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_6
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "Invalid clause_type: None or empty. Must be one of ['APPLICATION_POLICY_KNOBS', 'BUSINESS_RELEVANCE']."
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_7(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_7
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "no extra application sets can be added to the application policy"
+        )
+
+    def test_application_policy_workflow_manager_playbook_error_8(self):
+        """
+        Test the Application Policy Workflow Manager's update process from server name to URL.
+
+        This test verifies that the workflow correctly updates an application by replacing
+        the server name with a URL, ensuring proper validation and expected behavior.
+        """
+        set_module_args(
+            dict(
+                dnac_host="1.1.1.1",
+                dnac_username="dummy",
+                dnac_password="dummy",
+                dnac_log=True,
+                state="merged",
+                config_verify=True,
+                dnac_version="2.3.7.6",
+                config=self.playbook_error_8
+            )
+        )
+        result = self.execute_module(changed=False, failed=True)
+        print(result)
+        self.assertEqual(
+            result.get("response"),
+            "SSID is required for wireless devices"
         )


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
bug - The module does not support switching between all interface speed and differrent interface speed

The module does not support switching between using a common configuration for all interface speeds and using different configurations for each interface speed. This limitation has been documented accordingly.

Unit Test added for Application policy 

Bug Fix: Documentation Update ()
Root Cause (if applicable): N/A
Fix Implemented: N/A

Enhancement: N/A
Enhancement Description: N/A
Impact Area: N/A

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

