### PR TITLE
Device config backup workflow module enhancement changes 

### DIFF
--- a/plugins/modules/device_configs_backup_workflow_manager.py
+++ b/plugins/modules/device_configs_backup_workflow_manager.py
@@ -1249,7 +1249,7 @@ class DeviceConfigsBackup(DnacBase):
                                 output_file_path = os.path.join(target_dir, os.path.basename(name))
                                 with open(output_file_path, "wb") as f:
                                     f.write(file_bytes)
-                                self.log("Extracted {} to: {}".format(name, output_file_path), "DEBUG")
+                                self.log("Extracted {} to: {}".format(name, output_file_path), "INFO")
                             except RuntimeError as re:
                                 self.log("Password error for {}: {}".format(name, re), "ERROR")
                 except Exception as e:

--- a/plugins/modules/device_configs_backup_workflow_manager.py
+++ b/plugins/modules/device_configs_backup_workflow_manager.py
@@ -367,9 +367,10 @@ EXAMPLES = r"""
         file_path: backup
         unzip_backup: false
         config_file_types:
-            - VLAN
-            - STARTUPCONFIG
-            - RUNNINGCONFIG
+          - VLAN
+          - STARTUPCONFIG
+          - RUNNINGCONFIG
+
 """
 RETURN = r"""
 # Case_1: Successful creation and exportation of device configs

--- a/plugins/modules/device_configs_backup_workflow_manager.py
+++ b/plugins/modules/device_configs_backup_workflow_manager.py
@@ -362,7 +362,6 @@ EXAMPLES = r"""
     config:
       - site_list: ["Global"]
         family_list: ["Switches and Hubs"]
-        series_list: ["Cisco Catalyst 9300 Series Switches"]
         ip_address_list: ["204.1.2.5"]
         file_path: backup
         unzip_backup: false


### PR DESCRIPTION
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Description
Device config backup workflow module enhancement changes:
• Adds support for selecting specific configuration file types to be downloaded per device.
• If not specified, all available configuration types will be downloaded by default.
• Supported in Cisco Catalyst Center version 2.3.7.9 and later.
• Example: ["VLAN", "STARTUPCONFIG", "RUNNINGCONFIG"]

Bug Fix: [Brief description of the bug fixed]
Root Cause (if applicable): [Explain what caused the bug]
Fix Implemented: [Describe the fix applied]

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

