### PR TITLE
TypeError: 'NoneType' error encountered during site processing when n…

### DIFF
--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -1340,10 +1340,14 @@ class Swim(DnacBase):
                 get_site_names = self.get_site(site_names)
                 self.log("Fetched site names: {0}".format(str(get_site_names)), "DEBUG")
 
-                for item in get_site_names['response']:
+                for item in get_site_names.get('response', []):
                     if 'nameHierarchy' in item and 'id' in item:
                         site_info[item['nameHierarchy']] = item['id']
-
+                    else:
+                        self.log(
+                            "Missing 'nameHierarchy' or 'id' in site item: {0}".format(str(item)),
+                            "WARNING"
+                        )
             self.log("Site information retrieved: {0}".format(str(site_info)), "DEBUG")
 
             for site_name, site_id in site_info.items():

--- a/plugins/modules/swim_workflow_manager.py
+++ b/plugins/modules/swim_workflow_manager.py
@@ -1335,12 +1335,16 @@ class Swim(DnacBase):
                     "ERROR",
                 )
 
-            get_site_names = self.get_site(site_names)
-            self.log("Fetched site names: {0}".format(str(get_site_names)), "DEBUG")
+            if site_type in ["area", "floor"]:
+                self.log("Fetching site names for pattern: {0}".format(site_names), "DEBUG")
+                get_site_names = self.get_site(site_names)
+                self.log("Fetched site names: {0}".format(str(get_site_names)), "DEBUG")
 
-            for item in get_site_names["response"]:
-                if "nameHierarchy" in item and "id" in item:
-                    site_info[item["nameHierarchy"]] = item["id"]
+                for item in get_site_names['response']:
+                    if 'nameHierarchy' in item and 'id' in item:
+                        site_info[item['nameHierarchy']] = item['id']
+
+            self.log("Site information retrieved: {0}".format(str(site_info)), "DEBUG")
 
             for site_name, site_id in site_info.items():
                 offset = 1
@@ -3130,6 +3134,9 @@ class Swim(DnacBase):
             self.msg = final_msg
             self.set_operation_result("success", True, self.msg, "INFO")
             self.partial_successful_distribution = True
+        elif device_ip_for_not_elg_list:
+            self.msg = "Devices not eligible for image distribution: " + ", ".join(device_ip_for_not_elg_list)
+            self.set_operation_result("success", False, self.msg, "WARNING")
         else:
             self.msg = final_msg
             self.set_operation_result("success", True, self.msg, "INFO")


### PR DESCRIPTION
…o sub-sites are present- Bug Fixed

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Please include a summary of the changes and the related issue. Also, include relevant motivation and context.

Bug Fix: TypeError: 'NoneType' error encountered during site processing when no sub-sites are present.
Root Cause (if applicable): NA
Fix Implemented: Site types like area and floor are now handled more directly by fetching their details. Areas use a wildcard pattern to retrieve all related sub-sites, while floors use the exact site name. Only building sites require extra handling to extract hierarchy info, as some buildings may not have floors defined.

Enhancement: NA
Enhancement Description: NA
Impact Area: NA
Testing Done:
- [x]  Manual testing
- [x]  Unit tests
- [x]  Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

