### PR TITLE
Changes the default value of creating/updating the fabric vlans from …

### DIFF
--- a/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
+++ b/plugins/modules/sda_fabric_virtual_networks_workflow_manager.py
@@ -39,10 +39,10 @@ options:
     description: Sets the maximum number of fabric VLANs
       that can be created or updated at a time via the
       SDA API, aligning with GUI constraints. The default
-      is 50, as the GUI allows creating up to 50 fabric
+      is 20, as the GUI allows creating up to 20 fabric
       VLANs at a time.
     type: int
-    default: 50
+    default: 20
   sda_fabric_gateway_limit:
     description: Sets the maximum number of anycast
       gateways that can be created or updated at a time
@@ -1399,7 +1399,7 @@ class VirtualNetwork(DnacBase):
             class status accordingly.
         """
 
-        req_limit = self.params.get("sda_fabric_vlan_limit", 50)
+        req_limit = self.params.get("sda_fabric_vlan_limit", 20)
         self.log(
             "API request batch size set to '{0}' for fabric VLAN creation.".format(
                 req_limit
@@ -1580,7 +1580,7 @@ class VirtualNetwork(DnacBase):
             and sets the status to "failed".
         """
 
-        req_limit = self.params.get("sda_fabric_vlan_limit", 50)
+        req_limit = self.params.get("sda_fabric_vlan_limit", 20)
         self.log(
             "API request batch size set to '{0}' for fabric VLAN updation.".format(
                 req_limit
@@ -5329,7 +5329,7 @@ def main():
         "dnac_log": {"type": "bool", "default": False},
         "validate_response_schema": {"type": "bool", "default": True},
         "config_verify": {"type": "bool", "default": False},
-        "sda_fabric_vlan_limit": {"type": "int", "default": 50},
+        "sda_fabric_vlan_limit": {"type": "int", "default": 20},
         "sda_fabric_gateway_limit": {"type": "int", "default": 20},
         "dnac_api_task_timeout": {"type": "int", "default": 1200},
         "dnac_task_poll_interval": {"type": "int", "default": 2},


### PR DESCRIPTION
…50 to 20 in a single request.

-- Fix the issue of changes the api default value of creating/updating the fabric vlans from 50 to 20 in a single request.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Please include a summary of the changes and the related issue. Also, include relevant motivation and context.

Bug Fix: [Brief description of the bug fixed]
Root Cause (if applicable): [Explain what caused the bug]
Fix Implemented: [Describe the fix applied]

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

