### PR TITLE
Wireless profile - Function name change to alias name

### DIFF
--- a/plugins/modules/network_profile_wireless_workflow_manager.py
+++ b/plugins/modules/network_profile_wireless_workflow_manager.py
@@ -179,8 +179,8 @@ notes:
     wireless.update_application_policy,
     wireless.get_wireless_profile,
     site_design.assign_sites,
-    wireless.get_interfaces_v1
-    wireless.create_interface_v1
+    wireless.get_interfaces
+    wireless.create_interface
   - Paths used are
     GET dna/intent/api/v1/wirelessProfiles
     POST dna/intent/api/v1/wirelessProfiles/{ GET /dna/intent/api/v1/app-policy-intent
@@ -1264,7 +1264,7 @@ class NetworkWirelessProfile(NetworkProfileFunctions):
         }
         try:
             interfaces = self.execute_get_request(
-                "wireless", "get_interfaces_v1", payload
+                "wireless", "get_interfaces", payload
             )
             if interfaces and isinstance(interfaces.get("response"), list):
                 self.log(
@@ -1290,7 +1290,7 @@ class NetworkWirelessProfile(NetworkProfileFunctions):
             )
             payload = {"interfaceName": interface, "vlanId": vlan_id}
             task_details = self.execute_process_task_data(
-                "wireless", "create_interface_v1", payload
+                "wireless", "create_interface", payload
             )
             if task_details:
                 self.log(


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
In the wireless profile, creating a profile with an additional interface was failing due to the use of an SDK function with the "_v1" suffix. This has been resolved by changing the function name to its alias.

Bug Fix:
The public SDK version did not support function names with the "_v1" suffix. To address this, the function names have been updated to use their alias names.

Root Cause (if applicable):
The issue was caused by the direct usage of function names with the "_v1" suffix instead of their alias names. This has been corrected by replacing the function names with their corresponding aliases.

Fix Implemented:
The function name "get_interfaces_v1" was changed to "get_interfaces".
Similarly, the function name "create_interface_v1" was updated to "create_interface".

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [x] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

