### PR TITLE
PNP Workflow - Validate duplicate serial number in playbook config

### DIFF
--- a/plugins/modules/pnp_workflow_manager.py
+++ b/plugins/modules/pnp_workflow_manager.py
@@ -503,16 +503,19 @@ class PnP(DnacBase):
             list: A list of serial numbers that appear more than once.
                 Returns an empty list if no duplicates are found.
         """
+        self.log("Starting the process to find duplicate serial numbers.", "INFO")
         seen_serials = set()
         duplicates = set()
 
         # Iterate through each device dictionary in the input list
-        for device in input_config:
+        for idx, device in enumerate(input_config):
+            self.log("Processing device at index {0}: {1}".format(idx, device), "DEBUG")
             # The "device_info" key contains a list, so we loop through it
             for info in device.get("device_info", []):
                 serial_number = info.get("serial_number")
 
                 if not serial_number:
+                    self.log("No serial number found in device info: {0}".format(info), "WARNING")
                     continue
 
                 if serial_number in seen_serials:
@@ -525,6 +528,9 @@ class PnP(DnacBase):
                     self.log("Adding serial number to seen list: {0}".format(
                         serial_number), "DEBUG")
                     seen_serials.add(serial_number)
+
+        self.log("Duplicate serial numbers found: {0}".format(list(duplicates)), "INFO")
+        self.log("Completed the process to find duplicate serial numbers.", "INFO")
 
         return list(duplicates)
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Bug raised for Duplicate serial number validation not there previously, need to be implemented now.

Bug Fix: To check any serial number repeated again, previously validation not there, now enabled the same. 
Root Cause (if applicable): [Explain what caused the bug]
Fix Implemented: 
Created new function to validate the playbook serial number. The function return the duplicate serial number

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [x] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

