### PR TITLE
Replace get_all_global_credentials_v2 for sdk 2.10.0 compatibility in device_credential_workflow_manager

### DIFF
--- a/plugins/modules/device_credential_workflow_manager.py
+++ b/plugins/modules/device_credential_workflow_manager.py
@@ -469,10 +469,10 @@ seealso:
     link: https://developer.cisco.com/docs/dna-center/sync-network-devices-credential
 notes:
   - SDK Method used are
-    discovery.Discovery.create_global_credentials_v2,
-    discovery.Discovery.delete_global_credential_v2,
-    discovery.Discovery.update_global_credentials_v2,
-    network_settings.NetworkSettings.assign_device_credential_to_site_v2,
+    discovery.Discovery.create_global_credentials,
+    discovery.Discovery.delete_global_credential,
+    discovery.Discovery.update_global_credentials,
+    network_settings.NetworkSettings.assign_device_credential_to_site,
     network_settings.NetworkSettings.get_device_credential_settings_for_a_site,
     network_settings.NetworkSettings.update_device_credential_settings_for_a_site,
     network_settings.NetworkSettings.sync_network_devices_credential,
@@ -1103,7 +1103,7 @@ class DeviceCredential(DnacBase):
         try:
             global_credentials = self.dnac._exec(
                 family="discovery",
-                function="get_all_global_credentials_v2",
+                function="get_all_global_credentials",
             )
             global_credentials = global_credentials.get("response")
             self.log(
@@ -2994,12 +2994,12 @@ class DeviceCredential(DnacBase):
         )
         response = self.dnac._exec(
             family="discovery",
-            function="create_global_credentials_v2",
+            function="create_global_credentials",
             op_modifies=True,
             params=credential_params,
         )
         self.log(
-            "Received API response from 'create_global_credentials_v2': {0}".format(
+            "Received API response from 'create_global_credentials': {0}".format(
                 response
             ),
             "DEBUG",
@@ -3010,11 +3010,11 @@ class DeviceCredential(DnacBase):
         ):
             validation_string = "global credential addition performed"
             self.check_task_response_status(
-                response, validation_string, "create_global_credentials_v2"
+                response, validation_string, "create_global_credentials"
             ).check_return_status()
         else:
             self.check_tasks_response_status(
-                response, "create_global_credentials_v2"
+                response, "create_global_credentials"
             ).check_return_status()
 
         self.log("Global credential created successfully", "INFO")
@@ -3090,12 +3090,12 @@ class DeviceCredential(DnacBase):
                 final_response.append(credential_params)
                 response = self.dnac._exec(
                     family="discovery",
-                    function="update_global_credentials_v2",
+                    function="update_global_credentials",
                     op_modifies=True,
                     params=credential_params,
                 )
                 self.log(
-                    "Received API response for 'update_global_credentials_v2': {0}".format(
+                    "Received API response for 'update_global_credentials': {0}".format(
                         response
                     ),
                     "DEBUG",
@@ -3107,11 +3107,11 @@ class DeviceCredential(DnacBase):
                 ):
                     validation_string = "global credential update performed"
                     self.check_task_response_status(
-                        response, validation_string, "update_global_credentials_v2"
+                        response, validation_string, "update_global_credentials"
                     ).check_return_status()
                 else:
                     self.check_tasks_response_status(
-                        response, "update_global_credentials_v2"
+                        response, "update_global_credentials"
                     ).check_return_status()
 
         self.log(
@@ -3404,19 +3404,19 @@ class DeviceCredential(DnacBase):
                 final_response.append(copy.deepcopy(credential_params_template))
                 response = self.dnac._exec(
                     family="network_settings",
-                    function="assign_device_credential_to_site_v2",
+                    function="assign_device_credential_to_site",
                     op_modifies=True,
                     params=credential_params_template,
                 )
                 self.log(
-                    "Received API response for 'assign_device_credential_to_site_v2': {0}".format(
+                    "Received API response for 'assign_device_credential_to_site': {0}".format(
                         response
                     ),
                     "DEBUG",
                 )
                 validation_string = "desired common settings operation successful"
                 self.check_task_response_status(
-                    response, validation_string, "assign_device_credential_to_site_v2"
+                    response, validation_string, "assign_device_credential_to_site"
                 ).check_return_status()
             else:
                 credential_params = copy.deepcopy(
@@ -3880,12 +3880,12 @@ class DeviceCredential(DnacBase):
                 changed_status = True
                 response = self.dnac._exec(
                     family="discovery",
-                    function="delete_global_credential_v2",
+                    function="delete_global_credential",
                     op_modifies=True,
                     params={"id": _id},
                 )
                 self.log(
-                    "Received API response for 'delete_global_credential_v2': {0}".format(
+                    "Received API response for 'delete_global_credential': {0}".format(
                         response
                     ),
                     "DEBUG",


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
This PR includes bug fix for: IaC 3.0 device_credential_workflow_manager fails, Exception "Discovery' object has no attribute 'get_all_global_credentials_v2'

Bug Fix: Playbook failed on SDK 2.10.0 with exception: 'Discovery' object has no attribute 'get_all_global_credentials_v2'.
Root Cause (if applicable): get_all_global_credentials_v2 alias removed in dnacentersdk 2.10.0.
Fix Implemented: Replaced usage of alias with actual method call to restore compatibility.

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

