### PR TITLE
Bug Fix: Replace invalid SDK call in Discovery Workflow Manager

### DIFF
--- a/plugins/modules/discovery_workflow_manager.py
+++ b/plugins/modules/discovery_workflow_manager.py
@@ -478,7 +478,7 @@ requirements:
   - python >= 3.9
 notes:
   - SDK Method used are
-    discovery.Discovery.get_all_global_credentials_v2,
+    discovery.Discovery.get_all_global_credentials,
     discovery.Discovery.start_discovery,
     task.Task.get_task_by_id,
     discovery.Discovery.get_discoveries_by_range,
@@ -936,7 +936,7 @@ class Discovery(DnacBase):
         are passed as input.
 
         Parameters:
-            - response: The response collected from the get_all_global_credentials_v2 API
+            - response: The response collected from the get_all_global_credentials API
 
         Returns:
             - global_credentials_all  : The dictionary containing list of IDs of various types of
@@ -1160,7 +1160,7 @@ class Discovery(DnacBase):
     def get_ccc_global_credentials_v2_info(self):
         """
         Retrieve the global credentials information (version 2).
-        It applies the 'get_all_global_credentials_v2' function and extracts
+        It applies the 'get_all_global_credentials' function and extracts
         the IDs of the credentials. If no credentials are found, the
         function fails with a message.
 
@@ -1173,7 +1173,7 @@ class Discovery(DnacBase):
 
         response = self.dnac_apply["exec"](
             family="discovery",
-            function="get_all_global_credentials_v2",
+            function="get_all_global_credentials",
             params=self.validated_config[0].get("headers"),
             op_modifies=True,
         )


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: Fixed AttributeError caused by calling a non-existent SDK method `get_all_global_credentials_v2`.
Root Cause (if applicable): The SDK `Discovery` object only provides `get_all_global_credentials`; the `_v2` version does not exist. This was caused due to the recent sdk changes in https://github.com/cisco-en-programmability/dnacentersdk/pull/216

Fix Implemented: Updated `discovery_workflow_manager.py` to replace `get_all_global_credentials_v2` with `get_all_global_credentials`. Also updated related docstrings and comments.

Enhancement: N/A
Enhancement Description: N/A
Impact Area: discovery_workflow_manager.py — specifically method `get_ccc_global_credentials_v2_info` and SDK references.

Testing Done:
- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests

Test cases covered: TC#1: Test_TC1_site_create

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
Updated SDK method to fix regression; please verify if similar incorrect references exist elsewhere.
