### PR TITLE
synchronize_to_health_threshold and threshold_value in System Defined…

### DIFF
--- a/plugins/modules/assurance_issue_workflow_manager.py
+++ b/plugins/modules/assurance_issue_workflow_manager.py
@@ -361,7 +361,7 @@ options:
               the health threshold. Accepts "true" or
               "false".
             type: bool
-            required: true
+            required: false
           priority:
             description: >
               Specifies the priority level of the issue.
@@ -391,7 +391,7 @@ options:
               Must not exceed 0 dBm, meaning it should
               be a negative value.
             type: int
-            required: true
+            required: false
       assurance_issue:
         description: >
           Allow to resolve, ignore, or execute commands
@@ -1106,8 +1106,8 @@ class AssuranceSettings(DnacBase):
                 "issue_enabled": {"type": "bool"},
                 "device_type": {"type": "str", "required": True},
                 "priority": {"type": "str", "choices": ["P1", "P2", "P3", "P4"]},
-                "synchronize_to_health_threshold": {"type": "bool"},
-                "threshold_value": {"type": int},
+                "synchronize_to_health_threshold": {"type": "bool", "required": False},
+                "threshold_value": {"type": int, "required": False},
             },
             "assurance_issue": {
                 "type": "list",


### PR DESCRIPTION
… Issues shouldn't be mandatory

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: Made synchronize_to_health_threshold and threshold_value in System Defined Issues optional for Assurance [IAC3].

Root Cause: These parameters were incorrectly marked as mandatory in the schema and module logic, causing failures when they were not provided by the user.

Fix Implemented: Updated the input schema to make both synchronize_to_health_threshold and threshold_value optional. 

Enhancement: [Brief description of the improvement/enhancement made]
Enhancement Description: [Explain what was enhanced, why, and how]
Impact Area: [Mention which part of the system/codebase is affected]

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

