### PR TITLE
2 Bug Fixes for SDA Host Port Onboarding Module

### DIFF
--- a/plugins/modules/sda_host_port_onboarding_workflow_manager.py
+++ b/plugins/modules/sda_host_port_onboarding_workflow_manager.py
@@ -963,16 +963,16 @@ class SDAHostPortOnboarding(DnacBase):
                         "required": False,
                         "options": {
                             "ssid_name": {"type": "str"},
-                            "security_group_name": {"type": "str"}
-                        }
-                    }
-                }
+                            "security_group_name": {"type": "str"},
+                        },
+                    },
+                },
             },
             "device_collection_status_check": {
                 "type": "bool",
                 "required": False,
-                "default": True
-            }
+                "default": True,
+            },
         }
 
         # Validate params
@@ -991,7 +991,9 @@ class SDAHostPortOnboarding(DnacBase):
         self.set_operation_result("success", False, self.msg, "INFO")
         return self
 
-    def validate_device_exists_and_reachable(self, ip_address, hostname, device_collection_status_check):
+    def validate_device_exists_and_reachable(
+        self, ip_address, hostname, device_collection_status_check
+    ):
         """
         Validates whether a device is present in the Catalyst Center, is reachable, and has an acceptable collection status.
         Args:
@@ -1058,26 +1060,32 @@ class SDAHostPortOnboarding(DnacBase):
                 "Skipping collection status check for device '{0}' as 'device_collection_status_check' is set to False.".format(
                     device_identifier
                 ),
-                "INFO"
+                "INFO",
             )
             return True
 
         # Check collection status
         if collection_status in ["In Progress", "Managed"]:
             self.log(
-                "Device '{0}' has an acceptable collection status: '{1}'.".format(device_identifier, collection_status),
-                "INFO"
+                "Device '{0}' has an acceptable collection status: '{1}'.".format(
+                    device_identifier, collection_status
+                ),
+                "INFO",
             )
             return True
 
         # Unacceptable collection status
         self.msg = (
             "Device '{0}' does not have an acceptable collection status. "
-            "Current collection status: '{1}'.".format(device_identifier, collection_status)
+            "Current collection status: '{1}'.".format(
+                device_identifier, collection_status
+            )
         )
         return False
 
-    def validate_ip_and_hostname(self, ip_address, hostname, device_collection_status_check):
+    def validate_ip_and_hostname(
+        self, ip_address, hostname, device_collection_status_check
+    ):
         """
         Validates the provided IP address and hostname.
         Args:
@@ -1113,7 +1121,9 @@ class SDAHostPortOnboarding(DnacBase):
             self.fail_and_exit(self.msg)
 
         # Check if device exists and is reachable in Catalyst Center
-        if not self.validate_device_exists_and_reachable(ip_address, hostname, device_collection_status_check):
+        if not self.validate_device_exists_and_reachable(
+            ip_address, hostname, device_collection_status_check
+        ):
             self.fail_and_exit(self.msg)
 
         self.log("Validation successful: Provided IP address or hostname are valid")
@@ -1869,16 +1879,20 @@ class SDAHostPortOnboarding(DnacBase):
             )
             self.fail_and_exit(self.msg)
 
-        is_port_operation_requested = bool(port_assignment_details or port_channel_details)
+        is_port_operation_requested = bool(
+            port_assignment_details or port_channel_details
+        )
         is_delete_all_operation = state == "deleted" and (ip_address or hostname)
 
         if is_port_operation_requested or is_delete_all_operation:
             self.log(
                 "Validation triggered: Port assignment/Port Channel operation requested "
                 "or 'delete all' operation detected. Validating IP and Hostname.",
-                "DEBUG"
+                "DEBUG",
             )
-            self.validate_ip_and_hostname(ip_address, hostname, device_collection_status_check)
+            self.validate_ip_and_hostname(
+                ip_address, hostname, device_collection_status_check
+            )
 
         if state == "merged":
             # Validate parameters for add/update in port assignments
@@ -5392,7 +5406,9 @@ class SDAHostPortOnboarding(DnacBase):
                 )
                 if ip_address[0] is not None or hostname is not None:
                     self.log(
-                        "IP address or hostname provided. Updating network details for deletion operation. ip_address: {0}, hostname: {1}".format(ip_address, hostname),
+                        "IP address or hostname provided. Updating network details for deletion operation. ip_address: {0}, hostname: {1}".format(
+                            ip_address, hostname
+                        ),
                         "DEBUG",
                     )
                     update_network_details()


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
Includes following Bug Fixes:

1. IaC3.0 sda_host_port_onboarding_workflow_manager , host on boarding not working for fabric edge in fabric zone
2. Cannot Delete just ALL wireless SSIDs mappings from a fabric site

Testing Done:
- [] Manual testing
- [] Unit tests
- [] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [ ] Tasks are idempotent (can be run multiple times without changing state)
- [ ] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [ ] Playbooks are modular and reusable
- [ ] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [ ] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

