### PR TITLE
SDA Host Port Onboarding Module - Updated bug fix for - host on boarding not working for fabric edge in fabric zone

### DIFF
--- a/plugins/modules/sda_host_port_onboarding_workflow_manager.py
+++ b/plugins/modules/sda_host_port_onboarding_workflow_manager.py
@@ -2184,6 +2184,12 @@ class SDAHostPortOnboarding(DnacBase):
             It logs the response, processes the response to extract the fabric zone ID, and handles any exceptions
             that occur during the API call.
         """
+        self.log(
+            "Retrieving fabric zones information for site: '{0}' with site ID: '{1}'.".format(
+                site_name, site_id
+            ),
+            "DEBUG",
+        )
         try:
             # Call the SDA 'get_fabric_zones' API with the provided site ID
             response = self.dnac._exec(
@@ -2193,8 +2199,8 @@ class SDAHostPortOnboarding(DnacBase):
                 params={"siteId": site_id},
             )
             self.log(
-                "Response received post SDA - 'get_fabric_zones' API call: {0}".format(
-                    str(response)
+                "Response received post SDA - 'get_fabric_zones' API call for site {0}: {1}".format(
+                    site_name, str(response)
                 ),
                 "DEBUG",
             )
@@ -2202,12 +2208,20 @@ class SDAHostPortOnboarding(DnacBase):
             response = response.get("response")
             if not response:
                 self.log(
-                    "No response received from the SDA - 'get_fabric_zones' API call.",
+                    "No response received from the SDA - 'get_fabric_zones' API call for site {0} with ID: {1}.".format(
+                        site_name, site_id
+                    ),
                     "WARNING",
                 )
                 return None
 
             fabric_zone_id = response[0]["id"]
+            self.log(
+                "Successfully retrieved fabric zone id for site {0} : '{1}'.".format(
+                    site_name, fabric_zone_id
+                ),
+                "INFO",
+            )
             return fabric_zone_id
 
         except Exception as e:


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description
This PR updates the bug fix for the following bug:
IaC3.0 sda_host_port_onboarding_workflow_manager , host on boarding not working for fabric edge in fabric zone
Code Changes: Now the module handles port onboarding for Edge Devices in Fabric Zone. 

Testing Done:
- [x] Manual testing
- [x] Unit tests
- [x] Integration tests

Test cases covered: [Mention test case IDs or brief points]

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [x] All options and parameters are documented clearly.
- [x] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers

