### PR TITLE
Bug Fix: SDA Fabric Workflow Manager: Fixed error while configuring a standalone wireless controller

### DIFF
--- a/plugins/modules/sda_fabric_devices_workflow_manager.py
+++ b/plugins/modules/sda_fabric_devices_workflow_manager.py
@@ -3459,7 +3459,7 @@ class FabricDevices(DnacBase):
         ]
         for device_role in device_roles:
             if device_role not in valid_device_roles_list:
-                self.msg = f"The value '{device_role}' in 'device_roles' for the IP '{device_ip}' should be in the list '{", ".join(valid_device_roles_list)}'."
+                self.msg = f"The value '{device_role}' in 'device_roles' for the IP '{device_ip}' should be in the list '{', '.join(valid_device_roles_list)}'."
                 self.fail_and_exit(self.msg)
 
         return


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Description

Bug Fix: Adding a device role as `WIRELESS_CONTROLLER_NODE` for a dedicated Wireless LAN Controller (WLC) device was failing with error `Field : deviceRoles is required`.  

Root Cause: The code was always removing `WIRELESS_CONTROLLER_NODE` from `device_roles` before calling the `add_fabric_devices` API. This was correct for switches with **embedded wireless controller capabilities**  but incorrect for standalone WLC devices.  

Fix Implemented: Introduced a new flag `embedded_wireless_controller_capabilities` in `device_info` to distinguish between switches and standalone WLC devices.  
- For **standalone WLC devices**, keep `WIRELESS_CONTROLLER_NODE` in the payload.  
- For **switches with embedded wireless controller capabilities**, remove the role before sending to API if it is not present in existing device roles.  
Also refactored role validation logic into a new helper method `validate_device_roles()` for clarity and consistency.  

Enhancement:  
- Improved logging and error messages for device role validation.  
- Clear distinction between embedded WLC and standalone WLC behavior.  

Enhancement Description: This ensures correct handling of device roles across different device types and avoids regressions in the embedded WLC workflow.  
Impact Area: `sda_fabric_devices_workflow_manager.py` module, specifically device role handling in `get_device_params` and WLC configuration workflow.  

Testing Done:
- [x] Manual testing  
  - Added a switch with `CONTROL_PLANE_NODE` → success  
  - Added a standalone WLC with `WIRELESS_CONTROLLER_NODE` → success  
  - Added a switch with embedded WLC settings → success
- [ ] Unit tests  
- [ ] Integration tests  

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] All the sanity checks have been completed and the sanity test cases have been executed

## Ansible Best Practices
- [x] Tasks are idempotent (can be run multiple times without changing state)
- [x] Variables and secrets are handled securely (e.g., using `ansible-vault` or environment variables)
- [x] Playbooks are modular and reusable
- [x] Handlers are used for actions that need to run on change

## Documentation
- [ ] All options and parameters are documented clearly.
- [ ] Examples are provided and tested.
- [x] Notes and limitations are clearly stated.

## Screenshots (if applicable)

## Notes to Reviewers
This fix addresses a regression introduced while implementing embedded wireless controller capabilities.  
Special care was taken to differentiate between standalone WLC devices and switches with embedded WLC roles, ensuring both workflows work without conflict.
